### PR TITLE
Removed some unnecesary parameters for jittertemp_filter

### DIFF
--- a/examples/stochastic_CH/assimilate_data_jittertemp.py
+++ b/examples/stochastic_CH/assimilate_data_jittertemp.py
@@ -12,8 +12,7 @@ xpoints = 40
 model = ndg.Camsholm(100, nsteps, xpoints)
 MALA = True
 verbose = True
-jtfilter = ndg.jittertemp_filter(n_temp=4, n_jitt=4, rho=0.99,
-                                 verbose=verbose, MALA=MALA)
+jtfilter = ndg.jittertemp_filter(n_jitt=4, verbose=verbose, MALA=MALA)
 
 nensemble = [5, 5, 5, 5]
 jtfilter.setup(nensemble, model)

--- a/nudging/pfilter.py
+++ b/nudging/pfilter.py
@@ -201,7 +201,7 @@ class bootstrap_filter(base_filter):
 
 
 class jittertemp_filter(base_filter):
-    def __init__(self, n_jitt, delta=None,
+    def __init__(self, n_jitt, delta,
                  verbose=False, MALA=False, nudging=False,
                  visualise_tape=False):
         self.delta = delta


### PR DESCRIPTION
Removed some unnecesary parameters in the initialisation of the jittertemp_filter for the stochastic CH equation, and removed the None default value of delta.