### PR TITLE
Changed parameters of jittertemp_filter and renamed fd.Control to fd.adjoint.Control.

### DIFF
--- a/examples/stochastic_CH/assimilate_data_jittertemp.py
+++ b/examples/stochastic_CH/assimilate_data_jittertemp.py
@@ -12,7 +12,8 @@ xpoints = 40
 model = ndg.Camsholm(100, nsteps, xpoints)
 MALA = True
 verbose = True
-jtfilter = ndg.jittertemp_filter(n_jitt=4, delta=0.1, verbose=verbose, MALA=MALA)
+jtfilter = ndg.jittertemp_filter(n_jitt=4, delta=0.1, 
+                                 verbose=verbose, MALA=MALA)
 
 nensemble = [5, 5, 5, 5]
 jtfilter.setup(nensemble, model)

--- a/examples/stochastic_CH/assimilate_data_jittertemp.py
+++ b/examples/stochastic_CH/assimilate_data_jittertemp.py
@@ -12,8 +12,7 @@ xpoints = 40
 model = ndg.Camsholm(100, nsteps, xpoints)
 MALA = True
 verbose = True
-jtfilter = ndg.jittertemp_filter(n_jitt=4, delta=0.1, 
-                                 verbose=verbose, MALA=MALA)
+jtfilter = ndg.jittertemp_filter(n_jitt=4, delta=0.1, verbose=verbose)
 
 nensemble = [5, 5, 5, 5]
 jtfilter.setup(nensemble, model)

--- a/examples/stochastic_CH/assimilate_data_jittertemp.py
+++ b/examples/stochastic_CH/assimilate_data_jittertemp.py
@@ -12,8 +12,7 @@ xpoints = 40
 model = ndg.Camsholm(100, nsteps, xpoints)
 MALA = True
 verbose = True
-jtfilter = ndg.jittertemp_filter(n_temp=4, n_jitt=4, rho=0.99,
-                                 verbose=verbose, MALA=MALA)
+jtfilter = ndg.jittertemp_filter(n_jitt=4, delta=0.1, verbose=verbose, MALA=MALA)
 
 nensemble = [5, 5, 5, 5]
 jtfilter.setup(nensemble, model)

--- a/nudging/models/stochastic_Camassa_Holm.py
+++ b/nudging/models/stochastic_Camassa_Holm.py
@@ -5,7 +5,7 @@ import numpy as np
 
 
 class Camsholm(base_model):
-    def __init__(self, n, nsteps, xpoints, seed, lambdas=False,
+    def __init__(self, n, nsteps, xpoints, seed=12353, lambdas=False,
                  dt=0.025, alpha=1.0, mu=0.01, salt=False):
 
         self.n = n
@@ -144,7 +144,7 @@ class Camsholm(base_model):
     def controls(self):
         controls_list = []
         for i in range(len(self.X)):
-            controls_list.append(fd.Control(self.X[i]))
+            controls_list.append(fd.adjoint.Control(self.X[i]))
         return controls_list
 
     def obs(self):

--- a/nudging/models/stochastic_euler.py
+++ b/nudging/models/stochastic_euler.py
@@ -147,7 +147,7 @@ class Euler_SD(base_model):
     def controls(self):
         controls_list = []
         for i in range(len(self.X)):
-            controls_list.append(fd.Control(self.X[i]))
+            controls_list.append(fd.adjoint.Control(self.X[i]))
         return controls_list
 
     def obs(self):

--- a/nudging/pfilter.py
+++ b/nudging/pfilter.py
@@ -201,7 +201,7 @@ class bootstrap_filter(base_filter):
 
 
 class jittertemp_filter(base_filter):
-    def __init__(self, n_jitt, delta=None,
+    def __init__(self, n_jitt, delta,
                  verbose=False, MALA=False, nudging=False,
                  visualise_tape=False):
         self.delta = delta


### PR DESCRIPTION
Changed parameters of jittertemp_filter on the stochastic CH example (added delta, and deleted n_temp and rho), renamed fd.Control to fd.adjoint.Control in the models, and set a default value to seed for Camsholm.