### PR TITLE
Clean-up of the linear SDE example 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# JSON files
+*.json

--- a/.gitignore
+++ b/.gitignore
@@ -135,4 +135,7 @@ dmypy.json
 *.npy
 *.jpg
 *.png 
+*.pickle
+*.pkl
+*.npz
 

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,9 @@ dmypy.json
 
 # JSON files
 *.json
+
+# Output files
+*.npy
+*.jpg
+*.png 
+

--- a/examples/linear_SDE/config.yaml
+++ b/examples/linear_SDE/config.yaml
@@ -1,5 +1,12 @@
 T: 1.0
 nsteps: 5
-A: 1.0
+# Model parameters 
+# For the linear SDE dx = -A*x*dt + D*dW
+A: 1.0 
 D: 1.0
+# Number of ranks (processes)
 nranks: 8
+# Number of particles per rank
+p_per_rank: 50
+# Verbose output
+verbose: True

--- a/examples/linear_SDE/config.yaml
+++ b/examples/linear_SDE/config.yaml
@@ -1,0 +1,5 @@
+T: 1.0
+nsteps: 5
+A: 1.0
+D: 1.0
+nranks: 8

--- a/examples/linear_SDE/linear_SDE_filter.py
+++ b/examples/linear_SDE/linear_SDE_filter.py
@@ -1,32 +1,36 @@
 from firedrake import dx
-from nudging import LSDEModel, \
-    jittertemp_filter, base_diagnostic, Stage
+from nudging import LSDEModel, jittertemp_filter, base_diagnostic, Stage
 import numpy as np
 from firedrake.petsc import PETSc
 
 Print = PETSc.Sys.Print
 # model
 # multiply by A and add D
-T = 1.
+T = 1.0
 nsteps = 5
-dt = T/nsteps
-A = 1.
+dt = T / nsteps
+A = 1.0
 D = 1.0
 model = LSDEModel(A=A, D=D, nsteps=nsteps, dt=dt, lambdas=True, seed=7123)
 
 p_per_rank = 10
 nranks = 30
-nensemble = [p_per_rank]*nranks
+nensemble = [p_per_rank] * nranks
 
-myfilter = jittertemp_filter(n_jitt=0, delta=0.15,
-                             verbose=2, MALA=False,
-                             visualise_tape=False, nudging=False, sigma=0.01)
-myfilter.setup(nensemble=nensemble, model=model,
-               residual=False)
+myfilter = jittertemp_filter(
+    n_jitt=0,
+    delta=0.15,
+    verbose=2,
+    MALA=False,
+    visualise_tape=False,
+    nudging=False,
+    sigma=0.01,
+)
+myfilter.setup(nensemble=nensemble, model=model, residual=False)
 
 # data
 c = 0.0
-d = D**2/2/A
+d = D**2 / 2 / A
 y0 = np.random.normal(loc=c, scale=np.sqrt(d))
 Print("Initial observation value:", y0)
 
@@ -36,8 +40,8 @@ y0 = -0.05563397349186569  # need to update from invariant distribution
 y.dat.data[:] = y0
 
 # prepare the initial ensemble
-c = 0.
-d = D**2/2/A
+c = 0.0
+d = D**2 / 2 / A
 for i in range(nensemble[myfilter.ensemble_rank]):
     dx0 = model.rg.normal(model.R, c, d)
     u = myfilter.ensemble[i][0]
@@ -48,7 +52,7 @@ S = 0.1
 
 
 def log_likelihood(y, Y):
-    ll = (y-Y)**2/S**2/2*dx
+    ll = (y - Y) ** 2 / S**2 / 2 * dx
     return ll
 
 
@@ -60,22 +64,16 @@ class samples(base_diagnostic):
 
 
 # wihout nudging
-nolambdasamples = samples(Stage.WITHOUT_LAMBDAS,
-                          myfilter.subcommunicators,
-                          nensemble)
+nolambdasamples = samples(Stage.WITHOUT_LAMBDAS, myfilter.subcommunicators, nensemble)
 
 # with nudging
-nudgingsamples = samples(Stage.AFTER_NUDGING,
-                         myfilter.subcommunicators,
-                         nensemble)
+nudgingsamples = samples(Stage.AFTER_NUDGING, myfilter.subcommunicators, nensemble)
 # after computing filteing step
-resamplingsamples = samples(Stage.AFTER_ASSIMILATION_STEP,
-                            myfilter.subcommunicators,
-                            nensemble)
+resamplingsamples = samples(
+    Stage.AFTER_ASSIMILATION_STEP, myfilter.subcommunicators, nensemble
+)
 
-diagnostics = [nudgingsamples,
-               resamplingsamples,
-               nolambdasamples]
+diagnostics = [nudgingsamples, resamplingsamples, nolambdasamples]
 
 tao_params = {
     "tao_type": "lmvm",
@@ -87,11 +85,14 @@ tao_params = {
 }
 
 
-myfilter.assimilation_step(y, log_likelihood,
-                           diagnostics=diagnostics,
-                           ess_tol=-9000.8,
-                           taylor_test=False,
-                           tao_params=tao_params)
+myfilter.assimilation_step(
+    y,
+    log_likelihood,
+    diagnostics=diagnostics,
+    ess_tol=-9000.8,
+    taylor_test=False,
+    tao_params=tao_params,
+)
 
 if myfilter.subcommunicators.global_comm.rank == 0:
     before, descriptors = nolambdasamples.get_archive()
@@ -104,9 +105,22 @@ if myfilter.subcommunicators.global_comm.rank == 0:
     bs_mean = np.mean(resampled)
     bs_var = np.var(resampled)
 
-    sigsq = D**2/2/A*(1 - np.exp(-2*A*T))
-    Sigsq = sigsq + np.exp(-2*A*T)*d
-    tmean = (Sigsq*y0 + np.exp(-A*T)*S**2*c)/(Sigsq + S**2)
-    tvar = Sigsq*S**2/(Sigsq + S**2)
+    sigsq = D**2 / 2 / A * (1 - np.exp(-2 * A * T))
+    Sigsq = sigsq + np.exp(-2 * A * T) * d
+    tmean = (Sigsq * y0 + np.exp(-A * T) * S**2 * c) / (Sigsq + S**2)
+    tvar = Sigsq * S**2 / (Sigsq + S**2)
 
-    print('True mean', tmean, 'ensemble mean', bs_mean, 'true var', tvar, 'ensemble var',  bs_var, 'diffmean' , abs(tmean - bs_mean), 'diffvar' ,abs(tvar - bs_var))
+    print(
+        "True mean",
+        tmean,
+        "ensemble mean",
+        bs_mean,
+        "true var",
+        tvar,
+        "ensemble var",
+        bs_var,
+        "diffmean",
+        abs(tmean - bs_mean),
+        "diffvar",
+        abs(tvar - bs_var),
+    )

--- a/examples/linear_SDE/linear_SDE_filter.py
+++ b/examples/linear_SDE/linear_SDE_filter.py
@@ -2,19 +2,41 @@ from firedrake import dx
 from nudging import LSDEModel, jittertemp_filter, base_diagnostic, Stage
 import numpy as np
 from firedrake.petsc import PETSc
+import yaml
+import sys
+import os
 
-Print = PETSc.Sys.Print
+Print = PETSc.Sys.Print  # Set up printing only on the first rank
+# Read the configuration from a yaml file. If a yaml file is not provided, use default settings
+if len(sys.argv) > 1:
+    with open(sys.argv[1], "r") as f:
+        config = yaml.safe_load(f)
+        Print("Configuration loaded from", sys.argv[1])
+else:
+    config = {}
+    config["T"] = 1.0
+    config["nsteps"] = 5
+    config["A"] = 1.0
+    config["D"] = 1.0
+    config["nranks"] = 8
+
 # model
 # multiply by A and add D
-T = 1.0
-nsteps = 5
+T = config["T"]
+nsteps = config["nsteps"]
 dt = T / nsteps
-A = 1.0
-D = 1.0
+A = config["A"]
+D = config["D"]
 model = LSDEModel(A=A, D=D, nsteps=nsteps, dt=dt, lambdas=True, seed=7123)
 
 p_per_rank = 10
-nranks = 30
+nranks = config["nranks"]  # total number of ranks
+max_n_rank = os.cpu_count()
+if nranks > max_n_rank:
+    Print(
+        f"Requested nranks {nranks} exceeds available cpu count {max_n_rank}, setting nranks to {max_n_rank}"
+    )
+    nranks = max_n_rank
 nensemble = [p_per_rank] * nranks
 
 myfilter = jittertemp_filter(

--- a/examples/linear_SDE/linear_SDE_filter.py
+++ b/examples/linear_SDE/linear_SDE_filter.py
@@ -5,6 +5,7 @@ from firedrake.petsc import PETSc
 import yaml
 import sys
 import os
+from rich.table import Table
 
 Print = PETSc.Sys.Print  # Set up printing only on the first rank
 # Read the configuration from a yaml file. If a yaml file is not provided, use default settings
@@ -19,17 +20,23 @@ else:
     config["A"] = 1.0
     config["D"] = 1.0
     config["nranks"] = 8
+    config["p_per_rank"] = 10
+    config["verbose"] = False
+    Print("Using default configuration with hardcoded parameters.")
 
 # model
+# The one-dimensional linear SDE dx = -A*x*dt + D*dW
 # multiply by A and add D
 T = config["T"]
 nsteps = config["nsteps"]
 dt = T / nsteps
-A = config["A"]
-D = config["D"]
+A = config["A"]  # positive, constant parameter
+D = config["D"]  # positive, constant parameter
+
+# Instantiate the model
 model = LSDEModel(A=A, D=D, nsteps=nsteps, dt=dt, lambdas=True, seed=7123)
 
-p_per_rank = 10
+p_per_rank = config["p_per_rank"]  # number of particles per rank
 nranks = config["nranks"]  # total number of ranks
 max_n_rank = os.cpu_count()
 if nranks > max_n_rank:
@@ -37,7 +44,8 @@ if nranks > max_n_rank:
         f"Requested nranks {nranks} exceeds available cpu count {max_n_rank}, setting nranks to {max_n_rank}"
     )
     nranks = max_n_rank
-nensemble = [p_per_rank] * nranks
+nensemble = [p_per_rank] * nranks  # ensemble size per rank
+
 
 myfilter = jittertemp_filter(
     n_jitt=0,
@@ -51,15 +59,19 @@ myfilter = jittertemp_filter(
 myfilter.setup(nensemble=nensemble, model=model, residual=False)
 
 # data
+# The ensemble is initialised as samples from N(0, D^2/(2A))
 c = 0.0
 d = D**2 / 2 / A
 y0 = np.random.normal(loc=c, scale=np.sqrt(d))
-Print("Initial observation value:", y0)
+if config["verbose"]:
+    Print("Initial observation value:", y0)
 
 
 y = model.obs()
 y0 = -0.05563397349186569  # need to update from invariant distribution
 y.dat.data[:] = y0
+if config["verbose"]:
+    Print("Initial observation assigned to observation function:", y.dat.data[:])
 
 # prepare the initial ensemble
 c = 0.0

--- a/examples/linear_SDE/linear_SDE_filter.py
+++ b/examples/linear_SDE/linear_SDE_filter.py
@@ -9,20 +9,29 @@ from rich.table import Table
 
 Print = PETSc.Sys.Print  # Set up printing only on the first rank
 # Read the configuration from a yaml file. If a yaml file is not provided, use default settings
-if len(sys.argv) > 1:
-    with open(sys.argv[1], "r") as f:
+opts = PETSc.Options()
+filename = opts.getString("-f", default=None)
+final_time = opts.getReal("-T", default=1.0)
+nsteps = opts.getInt("-n", default=5)
+parameter_A = opts.getReal("-A", default=1.0)
+parameter_D = opts.getReal("-D", default=1.0)
+nranks = opts.getInt("-r", default=8)
+particles_per_rank = opts.getInt("-p", default=10)
+verbose = opts.getBool("-v", default=False)
+if filename is not None:
+    with open(filename, "r") as f:
         config = yaml.safe_load(f)
-        Print("Configuration loaded from", sys.argv[1])
+        Print("Configuration loaded from", filename)
 else:
     config = {}
-    config["T"] = 1.0
-    config["nsteps"] = 5
-    config["A"] = 1.0
-    config["D"] = 1.0
-    config["nranks"] = 8
-    config["p_per_rank"] = 10
-    config["verbose"] = False
-    Print("Using default configuration with hardcoded parameters.")
+    config["T"] = final_time
+    config["nsteps"] = nsteps
+    config["A"] = parameter_A
+    config["D"] = parameter_D
+    config["nranks"] = nranks
+    config["p_per_rank"] = particles_per_rank
+    config["verbose"] = verbose
+    Print("Using configuration from command line arguments or default values.")
 
 # model
 # The one-dimensional linear SDE dx = -A*x*dt + D*dW
@@ -44,7 +53,7 @@ if nranks > max_n_rank:
         f"Requested nranks {nranks} exceeds available cpu count {max_n_rank}, setting nranks to {max_n_rank}"
     )
     nranks = max_n_rank
-nensemble = [p_per_rank] * nranks  # ensemble size per rank
+nensemble = [p_per_rank] * nranks  # list with ensemble size per rank
 
 
 myfilter = jittertemp_filter(
@@ -70,15 +79,20 @@ if config["verbose"]:
 y = model.obs()
 y0 = -0.05563397349186569  # need to update from invariant distribution
 y.dat.data[:] = y0
-if config["verbose"]:
-    Print("Initial observation assigned to observation function:", y.dat.data[:])
+
 
 # prepare the initial ensemble
+# Ensemble is initialized as samples from N(0, D^2/(2A))
+
 c = 0.0
 d = D**2 / 2 / A
+
+#
 for i in range(nensemble[myfilter.ensemble_rank]):
     dx0 = model.rg.normal(model.R, c, d)
+    Print(f"dx0: {dx0}")
     u = myfilter.ensemble[i][0]
+    Print(f"u : {u}")
     u.assign(dx0)
 
 # observation noise standard deviation

--- a/examples/stochastic_CH/assimilate_data_jittertemp.py
+++ b/examples/stochastic_CH/assimilate_data_jittertemp.py
@@ -16,29 +16,33 @@ jtfilter = ndg.jittertemp_filter(n_jitt=4, delta=0.1, verbose=verbose)
 
 nensemble = [5, 5, 5, 5]
 jtfilter.setup(nensemble, model)
-x, = fd.SpatialCoordinate(model.mesh)
+(x,) = fd.SpatialCoordinate(model.mesh)
 
 # prepare the initial ensemble
 exp = fd.exp
 for i in range(nensemble[jtfilter.ensemble_rank]):
-    dx0 = model.rg.normal(model.R, 0., 0.05)
-    dx1 = model.rg.normal(model.R, 0., 0.05)
-    a = model.rg.uniform(model.R, 0., 1.0)
-    b = model.rg.uniform(model.R, 0., 1.0)
-    u0_exp = (1+a)*0.2*2/(exp(x-403./15.+dx0)+exp(-x+403./15.+dx0))
-    u0_exp += (1+b)*0.5*2/(exp(x-203./15.+dx1)+exp(-x+203./15.+dx1))
+    dx0 = model.rg.normal(model.R, 0.0, 0.05)
+    dx1 = model.rg.normal(model.R, 0.0, 0.05)
+    a = model.rg.uniform(model.R, 0.0, 1.0)
+    b = model.rg.uniform(model.R, 0.0, 1.0)
+    u0_exp = (
+        (1 + a) * 0.2 * 2 / (exp(x - 403.0 / 15.0 + dx0) + exp(-x + 403.0 / 15.0 + dx0))
+    )
+    u0_exp += (
+        (1 + b) * 0.5 * 2 / (exp(x - 203.0 / 15.0 + dx1) + exp(-x + 203.0 / 15.0 + dx1))
+    )
     _, u = jtfilter.ensemble[i][0].split()
     u.interpolate(u0_exp)
 
 
 def log_likelihood(y, Y):
-    ll = (y-Y)**2/0.05**2/2*fd.dx
+    ll = (y - Y) ** 2 / 0.05**2 / 2 * fd.dx
     return ll
 
 
 # Load data
-y_exact = np.load('y_true.npy')
-y = np.load('y_obs.npy')
+y_exact = np.load("y_true.npy")
+y = np.load("y_obs.npy")
 N_obs = y.shape[0]
 
 yVOM = fd.Function(model.VVOM)
@@ -47,11 +51,11 @@ yVOM = fd.Function(model.VVOM)
 y_e_list = []
 y_sim_obs_list = []
 for m in range(y.shape[1]):
-    y_e_shared = ndg.SharedArray(partition=nensemble,
-                                 comm=jtfilter.subcommunicators.ensemble_comm)
+    y_e_shared = ndg.SharedArray(
+        partition=nensemble, comm=jtfilter.subcommunicators.ensemble_comm
+    )
     ecomm = jtfilter.subcommunicators.ensemble_comm
-    y_sim_obs_shared = ndg.SharedArray(partition=nensemble,
-                                       comm=ecomm)
+    y_sim_obs_shared = ndg.SharedArray(partition=nensemble, comm=ecomm)
     y_e_list.append(y_e_shared)
     y_sim_obs_list.append(y_sim_obs_shared)
 
@@ -60,7 +64,7 @@ if fd.COMM_WORLD.rank == 0:
     y_e = np.zeros((np.sum(nensemble), ys[0], ys[1]))
     y_e_asmfwd = np.zeros((np.sum(nensemble), ys[0], ys[1]))
     y_sim_obs_alltime_step = np.zeros((np.sum(nensemble), nsteps, ys[1]))
-    y_sim_obs_allobs_step = np.zeros((np.sum(nensemble), nsteps*N_obs, ys[1]))
+    y_sim_obs_allobs_step = np.zeros((np.sum(nensemble), nsteps * N_obs, ys[1]))
 
 # do assimiliation step
 for k in range(N_obs):
@@ -88,8 +92,9 @@ for k in range(N_obs):
             y_sim_obs_list[m].synchronise()
             if fd.COMM_WORLD.rank == 0:
                 y_sim_obs_alltime_step[:, step, m] = y_sim_obs_list[m].data()
-                y_sim_obs_allobs_step[:, nsteps*k+step, m] = \
-                    y_sim_obs_alltime_step[:, step, m]
+                y_sim_obs_allobs_step[:, nsteps * k + step, m] = y_sim_obs_alltime_step[
+                    :, step, m
+                ]
 
     # actually do the data assimilation step
     jtfilter.assimilation_step(yVOM, log_likelihood)

--- a/examples/stochastic_CH/generate_data.py
+++ b/examples/stochastic_CH/generate_data.py
@@ -13,10 +13,12 @@ model = ndg.Camsholm(100, nsteps, xpoints)
 model.setup()
 X_truth = model.allocate()
 _, u0 = X_truth[0].split()
-x, = fd.SpatialCoordinate(model.mesh)
+(x,) = fd.SpatialCoordinate(model.mesh)
 exp = fd.exp
-u0.interpolate(0.2*2/(exp(x-403./15.) + exp(-x+403./15.))
-               + 0.5*2/(exp(x-203./15.) + exp(-x+203./15.)))
+u0.interpolate(
+    0.2 * 2 / (exp(x - 403.0 / 15.0) + exp(-x + 403.0 / 15.0))
+    + 0.5 * 2 / (exp(x - 203.0 / 15.0) + exp(-x + 203.0 / 15.0))
+)
 N_obs = 50
 
 y_true = model.obs().dat.data[:]

--- a/examples/stochastic_KS/assimilate.py
+++ b/examples/stochastic_KS/assimilate.py
@@ -9,29 +9,32 @@ from nudging.models.stochastic_KS_CIP import KS_CIP
 
 import pickle
 
-with open("params.pickle", 'rb') as handle:
+with open("params.pickle", "rb") as handle:
     params = pickle.load(handle)
 
 nsteps = params["nsteps"]
 xpoints = params["xpoints"]
 L = params["L"]
-dt =params["dt"]
+dt = params["dt"]
 nu = params["nu"]
 dc = params["dc"]
-#dc = 2.5
+# dc = 2.5
 
-nensemble = [6]*16
+nensemble = [6] * 16
 
-model = KS_CIP(nsteps, xpoints, seed=12353, lambdas=True,
-               dt=dt, nu=nu, dc=dc, L=L)
+model = KS_CIP(nsteps, xpoints, seed=12353, lambdas=True, dt=dt, nu=nu, dc=dc, L=L)
 
 nudging = True
-jtfilter = ndg.jittertemp_filter(n_jitt=0, delta=0.15,
-                                 verbose=2, MALA=False,
-                                 visualise_tape="ks.pdf",
-                                 nudging=nudging, sigma=0.01)
+jtfilter = ndg.jittertemp_filter(
+    n_jitt=0,
+    delta=0.15,
+    verbose=2,
+    MALA=False,
+    visualise_tape="ks.pdf",
+    nudging=nudging,
+    sigma=0.01,
+)
 # jtfilter = ndg.bootstrap_filter(verbose=2)
-
 
 
 jtfilter.setup(nensemble, model)
@@ -45,33 +48,33 @@ with fd.CheckpointFile("../../DA_KS/ks_ensemble.h5", "r", comm=comm) as afile:
     mesh = afile.load_mesh("ksmesh")
     for i in range(nensemble[erank]):
         idx = i + offset[erank]
-        #print('shape of idx', idx)
+        # print('shape of idx', idx)
         u = jtfilter.new_ensemble[i][0]
-        u0 = afile.load_function(mesh, "u", idx = idx)
+        u0 = afile.load_function(mesh, "u", idx=idx)
         u.interpolate(u0)
 
+
 def log_likelihood(y, Y):
-    ll = (y-Y)**2/5.5**2/2*fd.dx
+    ll = (y - Y) ** 2 / 5.5**2 / 2 * fd.dx
     return ll
 
 
 # Load data
-y_exact = np.load('../../DA_KS/y_true.npy')
-y = np.load('../../DA_KS/y_obs.npy')
+y_exact = np.load("../../DA_KS/y_true.npy")
+y = np.load("../../DA_KS/y_obs.npy")
 
-PETSc.Sys.Print('shape of y', y.shape)
+PETSc.Sys.Print("shape of y", y.shape)
 N_obs = y.shape[0]
 # N_obs = 1
 
 yVOM = fd.Function(model.VVOM)
-#print('yvomShpe', yVOM.dat.data.shape)
+# print('yvomShpe', yVOM.dat.data.shape)
 
 # prepare shared arrays for data
 y_e_list = []
 y_sim_list = []
 for m in range(y.shape[0]):
-    y_e_shared = ndg.SharedArray(partition=nensemble,
-                                 comm=ecomm)
+    y_e_shared = ndg.SharedArray(partition=nensemble, comm=ecomm)
     y_e_list.append(y_e_shared)
     y_sim_list.append(y_e_shared)
 
@@ -85,17 +88,16 @@ diagnostics = []
 ### do simulation for  enesmble
 print("Warning, change N_sim back to 100")
 N_sim = 1
-#PETSc.Sys.Print('simulation step')
+# PETSc.Sys.Print('simulation step')
 for k in range(N_sim):
     PETSc.Sys.Print("Simulation Step", k)
     for i in range(nensemble[jtfilter.ensemble_rank]):
         model.randomize(jtfilter.new_ensemble[i])
-        model.run(jtfilter.new_ensemble[i], jtfilter.new_ensemble[i]) 
+        model.run(jtfilter.new_ensemble[i], jtfilter.new_ensemble[i])
         fwd_simdata = model.obs().dat.data[:]
         for m in range(y.shape[1]):
             y_sim_list[m].dlocal[i] = fwd_simdata[m]
-    
-    
+
     for m in range(y.shape[1]):
         y_sim_list[m].synchronise()
         if fd.COMM_WORLD.rank == 0:
@@ -107,13 +109,15 @@ for i in range(nensemble[jtfilter.ensemble_rank]):
 
 N_obs = 100
 # do assimiliation step
-#PETSc.Sys.Print('assimilation step')
+# PETSc.Sys.Print('assimilation step')
 for k in range(N_obs):
     PETSc.Sys.Print("Assimlation Step", k)
-    yVOM.dat.data[:] = y[k,:]
+    yVOM.dat.data[:] = y[k, :]
 
     # # # actually do the data assimilation step
-    jtfilter.assimilation_step(yVOM, log_likelihood,  ess_tol=80,  diagnostics=diagnostics)
+    jtfilter.assimilation_step(
+        yVOM, log_likelihood, ess_tol=80, diagnostics=diagnostics
+    )
 
     for i in range(nensemble[jtfilter.ensemble_rank]):
         model.un.assign(jtfilter.ensemble[i][0])
@@ -131,16 +135,14 @@ if fd.COMM_WORLD.rank == 0:
     np.save("../../DA_KS/bs_init_assimilated_ensemble.npy", y_e)
 
 
-
 # # do checkpointing for nudging afterwards
 CG2 = fd.FunctionSpace(model.mesh, "CG", 2)
 uout = fd.Function(CG2, name="u")
 
 erank = jtfilter.ensemble_rank
 filename = f"../../DA_KS/checkpoint_files/ensemble_bs{erank}.h5"
-with fd.CheckpointFile(filename, 'w', comm=jtfilter.subcommunicators.comm) as afile:
+with fd.CheckpointFile(filename, "w", comm=jtfilter.subcommunicators.comm) as afile:
     for i in range(nensemble[erank]):
         u = jtfilter.ensemble[i][0]
         uout.interpolate(u0)
         afile.save_function(uout, idx=i)
-

--- a/examples/stochastic_KS/final_assimilate.py
+++ b/examples/stochastic_KS/final_assimilate.py
@@ -9,35 +9,41 @@ from nudging.models.stochastic_KS_CIP import KS_CIP
 
 import pickle
 
-with open("params.pickle", 'rb') as handle:
+with open("params.pickle", "rb") as handle:
     params = pickle.load(handle)
 
 nsteps = params["nsteps"]
 xpoints = params["xpoints"]
 L = params["L"]
-dt =params["dt"]
+dt = params["dt"]
 nu = params["nu"]
 dc = params["dc"]
-#dc = 2.5
+# dc = 2.5
 
-nensemble = [1]*30
+nensemble = [1] * 30
 
-model = KS_CIP(nsteps, xpoints, seed=12353, lambdas=True,
-               dt=dt, nu=nu, dc=dc, L=L)
+model = KS_CIP(nsteps, xpoints, seed=12353, lambdas=True, dt=dt, nu=nu, dc=dc, L=L)
 
 nudging = True
-jtfilter = ndg.jittertemp_filter(n_jitt=5, delta=0.15,
-                             verbose=2, MALA=False,
-                             visualise_tape=False, nudging=nudging, sigma=0.01)
+jtfilter = ndg.jittertemp_filter(
+    n_jitt=5,
+    delta=0.15,
+    verbose=2,
+    MALA=False,
+    visualise_tape=False,
+    nudging=nudging,
+    sigma=0.01,
+)
 # jtfilter = ndg.bootstrap_filter(verbose=2)
-
 
 
 jtfilter.setup(nensemble, model)
 
 
 # load mesh
-with fd.CheckpointFile("../../DA_KS/ks_ensemble.h5", "r", comm=jtfilter.subcommunicators.comm) as afile:
+with fd.CheckpointFile(
+    "../../DA_KS/ks_ensemble.h5", "r", comm=jtfilter.subcommunicators.comm
+) as afile:
     mesh = afile.load_mesh("ksmesh")
 
 comm = jtfilter.subcommunicators.comm
@@ -45,34 +51,34 @@ ecomm = jtfilter.subcommunicators.ensemble_comm
 # load the initial ensemble
 erank = jtfilter.ensemble_rank
 filename = f"../../DA_KS/checkpoint_files/ensemble_temp{erank}.h5"
-with fd.CheckpointFile(filename, 'r', comm=jtfilter.subcommunicators.comm) as afile:
+with fd.CheckpointFile(filename, "r", comm=jtfilter.subcommunicators.comm) as afile:
     for i in range(nensemble[erank]):
         u = jtfilter.new_ensemble[i][0]
-        u0 = afile.load_function(mesh, "u", idx = i) # read locally
+        u0 = afile.load_function(mesh, "u", idx=i)  # read locally
         u.interpolate(u0)
 
+
 def log_likelihood(y, Y):
-    ll = (y-Y)**2/5.5**2/2*fd.dx
+    ll = (y - Y) ** 2 / 5.5**2 / 2 * fd.dx
     return ll
 
 
 # Load data
-y_exact = np.load('../../DA_KS/y_true.npy')
-y = np.load('../../DA_KS/y_obs.npy')
+y_exact = np.load("../../DA_KS/y_true.npy")
+y = np.load("../../DA_KS/y_obs.npy")
 
-PETSc.Sys.Print('shape of y', y.shape)
+PETSc.Sys.Print("shape of y", y.shape)
 N_obs = y.shape[0]
 # N_obs = 1
 
 yVOM = fd.Function(model.VVOM)
-#print('yvomShpe', yVOM.dat.data.shape)
+# print('yvomShpe', yVOM.dat.data.shape)
 
 # prepare shared arrays for data
 y_e_list = []
 y_sim_list = []
 for m in range(y.shape[0]):
-    y_e_shared = ndg.SharedArray(partition=nensemble,
-                                 comm=ecomm)
+    y_e_shared = ndg.SharedArray(partition=nensemble, comm=ecomm)
     y_e_list.append(y_e_shared)
     y_sim_list.append(y_e_shared)
 
@@ -89,22 +95,21 @@ class samples(ndg.base_diagnostic):
         model.un.assign(particle[0])
         return model.obs().dat.data[0]
 
-nolambdasamples = samples(ndg.Stage.WITHOUT_LAMBDAS,
-                          jtfilter.subcommunicators,
-                          nensemble)
 
-resamplingsamples = samples(ndg.Stage.AFTER_ASSIMILATION_STEP,
-                            jtfilter.subcommunicators,
-                            nensemble)
-nudgingsamples = samples(ndg.Stage.AFTER_NUDGING,
-                         jtfilter.subcommunicators,
-                         nensemble)
-aftertempering = samples(ndg.Stage.AFTER_TEMPER_RESAMPLE,
-                         jtfilter.subcommunicators,
-                         nensemble)
-afterjittering = samples(ndg.Stage.AFTER_ONE_JITTER_STEP,
-                          jtfilter.subcommunicators,
-                          nensemble)
+nolambdasamples = samples(
+    ndg.Stage.WITHOUT_LAMBDAS, jtfilter.subcommunicators, nensemble
+)
+
+resamplingsamples = samples(
+    ndg.Stage.AFTER_ASSIMILATION_STEP, jtfilter.subcommunicators, nensemble
+)
+nudgingsamples = samples(ndg.Stage.AFTER_NUDGING, jtfilter.subcommunicators, nensemble)
+aftertempering = samples(
+    ndg.Stage.AFTER_TEMPER_RESAMPLE, jtfilter.subcommunicators, nensemble
+)
+afterjittering = samples(
+    ndg.Stage.AFTER_ONE_JITTER_STEP, jtfilter.subcommunicators, nensemble
+)
 
 diagnostics = [aftertempering, afterjittering, resamplingsamples]
 
@@ -121,17 +126,20 @@ tao_params = {
 
 N_obs = 1
 # do assimiliation step
-#PETSc.Sys.Print('assimilation step')
+# PETSc.Sys.Print('assimilation step')
 for k in range(N_obs):
     PETSc.Sys.Print("Assimlation Step", k)
-    yVOM.dat.data[:] = y[k,:]
-
+    yVOM.dat.data[:] = y[k, :]
 
     # # # actually do the data assimilation step
-    jtfilter.assimilation_step(yVOM, log_likelihood, diagnostics=diagnostics,
-                                ess_tol=-990.8,
-                                taylor_test=False,
-                                tao_params=tao_params)
+    jtfilter.assimilation_step(
+        yVOM,
+        log_likelihood,
+        diagnostics=diagnostics,
+        ess_tol=-990.8,
+        taylor_test=False,
+        tao_params=tao_params,
+    )
 
     for i in range(nensemble[jtfilter.ensemble_rank]):
         model.un.assign(jtfilter.ensemble[i][0])
@@ -145,11 +153,9 @@ for k in range(N_obs):
             y_e[:, k, m] = y_e_list[m].data()
 
 if fd.COMM_WORLD.rank == 0:
-   
+
     print("ensemble shape", y_e.shape)
     if not nudging:
         np.save("../../DA_KS/final_tempjitt_assimilated_ensemble.npy", y_e)
     if nudging:
         np.save("../../DA_KS/final_nudge_assimilated_ensemble.npy", y_e)
-
-

--- a/examples/stochastic_KS/generate_data_and_ensemble.py
+++ b/examples/stochastic_KS/generate_data_and_ensemble.py
@@ -6,8 +6,9 @@ import nudging as ndg
 from nudging.models.stochastic_KS_CIP import KS_CIP
 
 import os
-os.makedirs('../../DA_KS/', exist_ok=True)
-os.makedirs('../../DA_KS/checkpoint_files/', exist_ok=True)
+
+os.makedirs("../../DA_KS/", exist_ok=True)
+os.makedirs("../../DA_KS/checkpoint_files/", exist_ok=True)
 """
 create some synthetic data/observation data at T_1 ---- T_Nobs
 Pick initial conditon
@@ -24,7 +25,7 @@ nsteps = 10
 params["nsteps"] = nsteps
 xpoints = 10
 params["xpoints"] = xpoints
-L = 10.
+L = 10.0
 params["L"] = L
 dt = 0.005
 params["dt"] = dt
@@ -33,15 +34,17 @@ params["nu"] = nu
 dc = 2.5
 params["dc"] = dc
 
-model = KS_CIP(nsteps, xpoints, seed=12353, lambdas=True,
-               dt=dt, nu=nu, dc=dc, L=L)
+model = KS_CIP(nsteps, xpoints, seed=12353, lambdas=True, dt=dt, nu=nu, dc=dc, L=L)
 model.setup()
 X_start = model.allocate()
-u_in = X_start[0] # u_initilization
-x, = fd.SpatialCoordinate(model.mesh)
+u_in = X_start[0]  # u_initilization
+(x,) = fd.SpatialCoordinate(model.mesh)
 
 # Setup initilization
-u_in.project(0.2*2/(fd.exp(x-403./15.) + fd.exp(-x+403./15.)) + 0.5*2/(fd.exp(x-203./15.)+fd.exp(-x+203./15.)))
+u_in.project(
+    0.2 * 2 / (fd.exp(x - 403.0 / 15.0) + fd.exp(-x + 403.0 / 15.0))
+    + 0.5 * 2 / (fd.exp(x - 203.0 / 15.0) + fd.exp(-x + 203.0 / 15.0))
+)
 
 
 print("Finding an initial state.")
@@ -49,7 +52,7 @@ for i in fd.ProgressBar("").iter(range(200)):
     model.randomize(X_start)
     model.run(X_start, X_start)  # run method for every time step
     u = fd.Function(model.Vdg)
-    u.rename('state')
+    u.rename("state")
     u.interpolate(model.un)
     truth_init.write(u)
 
@@ -57,8 +60,7 @@ print("generating ensemble.")
 
 Nensemble = 96  # size of the ensemble
 
-spread_steps = math.ceil(4./dt/nsteps)
-
+spread_steps = math.ceil(4.0 / dt / nsteps)
 
 
 X = model.allocate()
@@ -68,25 +70,24 @@ ndump = 20  # dump data
 p_dump = 0
 
 y_true = model.obs().dat.data[:]
-particle_in = np.zeros((y_true.size, Nensemble+1))
+particle_in = np.zeros((y_true.size, Nensemble + 1))
 
 
-with fd.CheckpointFile("../../DA_KS/ks_ensemble.h5", 'w') as afile:
+with fd.CheckpointFile("../../DA_KS/ks_ensemble.h5", "w") as afile:
     afile.save_mesh(model.mesh)
 
-    
     X[0].assign(X_start[0])
     for step in fd.ProgressBar("").iter(range(spread_steps)):
         model.randomize(X)
         model.run(X, X)
-    for i in range(Nensemble+1):
+    for i in range(Nensemble + 1):
         if i < Nensemble:
             print("Generating ensemble member", i)
         else:
             print("Generating 'true' value")
-        particle_in[:,i] = model.obs().dat.data[:]
+        particle_in[:, i] = model.obs().dat.data[:]
         u = fd.Function(model.Vdg)
-        u.rename('state')
+        u.rename("state")
         u.interpolate(model.un)
         particle_init.write(u)
 
@@ -109,7 +110,7 @@ for i in fd.ProgressBar("").iter(range(N_obs)):
     model.randomize(X)
     model.run(X, X)  # run method for every time step
     u = fd.Function(model.Vdg)
-    u.rename('state')
+    u.rename("state")
     u.interpolate(model.un)
     truth.write(u)
     y_true = model.obs().dat.data[:]
@@ -118,10 +119,11 @@ for i in fd.ProgressBar("").iter(range(N_obs)):
     y_true_data = np.save("y_true.npy", y_true_full)
     y_noise = np.random.normal(0.0, noise_var**0.5)
     y_obs = y_true + y_noise
-    y_obs_full[i,:] = y_obs
+    y_obs_full[i, :] = y_obs
 np.save("../../DA_KS/y_true.npy", y_true_full)
 np.save("../../DA_KS/y_obs.npy", y_obs_full)
 
 import pickle
-with open('params.pickle', 'wb') as handle:
+
+with open("params.pickle", "wb") as handle:
     pickle.dump(params, handle, protocol=pickle.HIGHEST_PROTOCOL)

--- a/examples/stochastic_KS/read_initial_ensemble.py
+++ b/examples/stochastic_KS/read_initial_ensemble.py
@@ -5,7 +5,7 @@ from firedrake.petsc import PETSc
 from nudging.models.stochastic_KS_CIP import KS_CIP
 import pickle
 
-with open("params.pickle", 'rb') as handle:
+with open("params.pickle", "rb") as handle:
     params = pickle.load(handle)
 
 nsteps = params["nsteps"]
@@ -16,15 +16,14 @@ nu = params["nu"]
 dc = params["dc"]
 
 verbose = True
-model = KS_CIP(nsteps, xpoints, seed=12353, lambdas=False,
-               dt=dt, nu=nu, dc=dc, L=L)
+model = KS_CIP(nsteps, xpoints, seed=12353, lambdas=False, dt=dt, nu=nu, dc=dc, L=L)
 model.setup()
 
 with fd.CheckpointFile("ks_ensemble.h5", "r") as afile:
     mesh = afile.load_mesh("ksmesh")
 
 
-#file0 = fd.VTKFile("initial_ensemble.pvd")
+# file0 = fd.VTKFile("initial_ensemble.pvd")
 X = model.allocate()
 u = X[0]
 
@@ -32,4 +31,4 @@ with fd.CheckpointFile("ks_ensemble.h5", "r") as afile:
     for i in fd.ProgressBar("").iter(range(20)):
         u0 = afile.load_function(mesh, "u", idx=i)
         u.interpolate(u0)
-        #file0.write(u)
+        # file0.write(u)

--- a/examples/stochastic_KS/test_jhat.py
+++ b/examples/stochastic_KS/test_jhat.py
@@ -11,19 +11,18 @@ import firedrake.adjoint as fadj
 
 import pickle
 
-with open("params.pickle", 'rb') as handle:
+with open("params.pickle", "rb") as handle:
     params = pickle.load(handle)
 
 nsteps = params["nsteps"]
 xpoints = params["xpoints"]
 L = params["L"]
-dt =params["dt"]
+dt = params["dt"]
 nu = params["nu"]
 dc = params["dc"]
-#dc = 2.5
+# dc = 2.5
 
-model = KS_CIP(nsteps, xpoints, seed=12353, lambdas=True,
-               dt=dt, nu=nu, dc=dc, L=L)
+model = KS_CIP(nsteps, xpoints, seed=12353, lambdas=True, dt=dt, nu=nu, dc=dc, L=L)
 model.setup()
 X_start = model.allocate()
 X_out = model.allocate()
@@ -31,18 +30,20 @@ u_in = X_start[0]
 
 with fd.CheckpointFile("../../DA_KS/ks_ensemble.h5", "r") as afile:
     mesh = afile.load_mesh("ksmesh")
-    u0 = afile.load_function(mesh, "u", idx = 1)
+    u0 = afile.load_function(mesh, "u", idx=1)
     u_in.interpolate(u0)
 
+
 def log_likelihood(y, Y):
-    ll = (y-Y)**2/5.5**2/2*fd.dx
+    ll = (y - Y) ** 2 / 5.5**2 / 2 * fd.dx
     return ll
 
+
 # Load data
-y_exact = np.load('../../DA_KS/y_true.npy')
-y = np.load('../../DA_KS/y_obs.npy')
+y_exact = np.load("../../DA_KS/y_true.npy")
+y = np.load("../../DA_KS/y_obs.npy")
 yVOM = fd.Function(model.VVOM)
-yVOM.dat.data[:] = y[0,:]
+yVOM.dat.data[:] = y[0, :]
 
 continue_annotation()
 
@@ -66,14 +67,14 @@ X_use = model.allocate()
 X_use[0].assign(X_start[0])
 
 for step in range(nsteps):
-    X_use[nsteps+1+step].assign(0.5)
-    scale[step].assign(0.)
+    X_use[nsteps + 1 + step].assign(0.5)
+    scale[step].assign(0.0)
 
 before = fnl(X_use + [yVOM] + scale)
 
 for step in range(nsteps):
-    X_use[nsteps+1+step].assign(0*X_use[nsteps+1+step])
-    #scale[step].assign(1.0)
+    X_use[nsteps + 1 + step].assign(0 * X_use[nsteps + 1 + step])
+    # scale[step].assign(1.0)
 
 after = fnl(X_use + [yVOM] + scale)
 

--- a/examples/stochastic_euler/assimilate_data.py
+++ b/examples/stochastic_euler/assimilate_data.py
@@ -17,22 +17,22 @@ x = fd.SpatialCoordinate(model.mesh)
 
 sin = fd.sin
 for i in range(nensemble[bfilter.ensemble_rank]):
-    a = model.rg.uniform(model.R, 0., 1.0)
-    q0_in = 0.1*(1+a)*sin(x[0])*sin(x[1])
+    a = model.rg.uniform(model.R, 0.0, 1.0)
+    q0_in = 0.1 * (1 + a) * sin(x[0]) * sin(x[1])
     q = bfilter.ensemble[i][0]
     q.interpolate(q0_in)
 
 
 def log_likelihood(y, Y):
-    ll = 0.5*(1/0.05**2)*((y[0]-Y[0])**2 + (y[1]-Y[1])**2)*fd.dx
+    ll = 0.5 * (1 / 0.05**2) * ((y[0] - Y[0]) ** 2 + (y[1] - Y[1]) ** 2) * fd.dx
     return ll
 
 
 # #Load data
-u1_exact = np.load('u_true_1.npy')
-u2_exact = np.load('u_true_2.npy')
-u_vel_1 = np.load('u_obs_true_1.npy')
-u_vel_2 = np.load('u_obs_true_2.npy')
+u1_exact = np.load("u_true_1.npy")
+u2_exact = np.load("u_true_2.npy")
+u_vel_1 = np.load("u_obs_true_1.npy")
+u_vel_2 = np.load("u_obs_true_2.npy")
 
 N_obs = u_vel_1.shape[0]
 
@@ -45,10 +45,12 @@ u_VOM.append(u2_VOM)
 u1_e_list = []
 u2_e_list = []
 for m in range(u_vel_1.shape[1]):
-    u1_e_shared = ndg.SharedArray(partition=nensemble,
-                                  comm=bfilter.subcommunicators.ensemble_comm)
-    u2_e_shared = ndg.SharedArray(partition=nensemble,
-                                  comm=bfilter.subcommunicators.ensemble_comm)
+    u1_e_shared = ndg.SharedArray(
+        partition=nensemble, comm=bfilter.subcommunicators.ensemble_comm
+    )
+    u2_e_shared = ndg.SharedArray(
+        partition=nensemble, comm=bfilter.subcommunicators.ensemble_comm
+    )
     u1_e_list.append(u1_e_shared)
     u2_e_list.append(u2_e_shared)
 
@@ -70,7 +72,7 @@ for k in range(N_obs):
         model.q0.assign(bfilter.ensemble[i][0])
         obsdata_1 = model.obs()[0].dat.data[:]
         obsdata_2 = model.obs()[1].dat.data[:]
-        for m in range(u_vel_1 .shape[1]):
+        for m in range(u_vel_1.shape[1]):
             u1_e_list[m].dlocal[i] = obsdata_1[m]
             u2_e_list[m].dlocal[i] = obsdata_2[m]
 

--- a/examples/stochastic_euler/assimilate_data_jittertemp.py
+++ b/examples/stochastic_euler/assimilate_data_jittertemp.py
@@ -12,11 +12,12 @@ model = ndg.Euler_SD(n, nsteps=nsteps)
 
 MALA = False
 verbose = True
-jtfilter = ndg.jittertemp_filter(n_temp=4, n_jitt=4, rho=0.99,
-                                 verbose=verbose, MALA=MALA)
+jtfilter = ndg.jittertemp_filter(
+    n_temp=4, n_jitt=4, rho=0.99, verbose=verbose, MALA=MALA
+)
 # Load data
-u_exact = np.load('u_true_data.npy')
-u_vel = np.load('u_obs_data.npy')
+u_exact = np.load("u_true_data.npy")
+u_vel = np.load("u_obs_data.npy")
 
 nensemble = [5, 5, 5, 5]
 
@@ -28,18 +29,21 @@ sin = fd.sin
 pi = fd.pi
 cos = fd.cos
 for i in range(nensemble[jtfilter.ensemble_rank]):
-    a = model.rg.uniform(model.R, 0., 1.0)
-    b = model.rg.uniform(model.R, 0., 1.0)
-    q0_in = a*sin(8*pi*x[0])*sin(8*pi*x[1])\
-        + 0.4*b*cos(6*pi*x[0])*cos(6*pi*x[1])\
-        + 0.02*a*sin(2*pi*x[0])+0.02*a*sin(2*pi*x[1])\
-        + 0.3*b*cos(10*pi*x[0])*cos(4*pi*x[1])
+    a = model.rg.uniform(model.R, 0.0, 1.0)
+    b = model.rg.uniform(model.R, 0.0, 1.0)
+    q0_in = (
+        a * sin(8 * pi * x[0]) * sin(8 * pi * x[1])
+        + 0.4 * b * cos(6 * pi * x[0]) * cos(6 * pi * x[1])
+        + 0.02 * a * sin(2 * pi * x[0])
+        + 0.02 * a * sin(2 * pi * x[1])
+        + 0.3 * b * cos(10 * pi * x[0]) * cos(4 * pi * x[1])
+    )
     q = jtfilter.ensemble[i][0]
     q.interpolate(q0_in)
 
 
 def log_likelihood(y, Y):
-    ll = (y-Y)**2/0.05**2/2*fd.dx
+    ll = (y - Y) ** 2 / 0.05**2 / 2 * fd.dx
     return ll
 
 
@@ -56,14 +60,10 @@ u2_sim_list = []
 
 ecomm = jtfilter.subcommunicators.ensemble_comm
 for m in range(u_vel.shape[1]):
-    u1_e_shared = ndg.SharedArray(partition=nensemble,
-                                  comm=ecomm)
-    u2_e_shared = ndg.SharedArray(partition=nensemble,
-                                  comm=ecomm)
-    u1_sim_shared = ndg.SharedArray(partition=nensemble,
-                                    comm=ecomm)
-    u2_sim_shared = ndg.SharedArray(partition=nensemble,
-                                    comm=ecomm)
+    u1_e_shared = ndg.SharedArray(partition=nensemble, comm=ecomm)
+    u2_e_shared = ndg.SharedArray(partition=nensemble, comm=ecomm)
+    u1_sim_shared = ndg.SharedArray(partition=nensemble, comm=ecomm)
+    u2_sim_shared = ndg.SharedArray(partition=nensemble, comm=ecomm)
     u1_e_list.append(u1_e_shared)
     u2_e_list.append(u2_e_shared)
     u1_sim_list.append(u1_sim_shared)
@@ -75,12 +75,12 @@ if fd.COMM_WORLD.rank == 0:
     u2_e = np.zeros((np.sum(nensemble), ushape[0], ushape[1]))
     u1_sim_obs_alltime_step = np.zeros((np.sum(nensemble), nsteps, ushape[1]))
     u2_sim_obs_alltime_step = np.zeros((np.sum(nensemble), nsteps, ushape[1]))
-    u1_sim_obs_allobs_step = np.zeros((np.sum(nensemble),
-                                       nsteps*ushape[0],
-                                       ushape[1]))
-    u2_sim_obs_allobs_step = np.zeros((np.sum(nensemble),
-                                       nsteps*ushape[0],
-                                       ushape[1]))
+    u1_sim_obs_allobs_step = np.zeros(
+        (np.sum(nensemble), nsteps * ushape[0], ushape[1])
+    )
+    u2_sim_obs_allobs_step = np.zeros(
+        (np.sum(nensemble), nsteps * ushape[0], ushape[1])
+    )
 
 # do assimiliation steps
 for k in range(N_obs):
@@ -112,11 +112,13 @@ for k in range(N_obs):
             u2_sim_list[m].synchronise()
             if fd.COMM_WORLD.rank == 0:
                 u1_sim_obs_alltime_step[:, step, m] = u1_sim_list[m].data()
-                u1_sim_obs_allobs_step[:, nsteps*k+step, m] = \
+                u1_sim_obs_allobs_step[:, nsteps * k + step, m] = (
                     u1_sim_obs_alltime_step[:, step, m]
+                )
                 u2_sim_obs_alltime_step[:, step, m] = u2_sim_list[m].data()
-                u2_sim_obs_allobs_step[:, nsteps*k+step, m] = \
+                u2_sim_obs_allobs_step[:, nsteps * k + step, m] = (
                     u2_sim_obs_alltime_step[:, step, m]
+                )
 
     jtfilter.assimilation_step(u_VOM, log_likelihood)
 
@@ -140,7 +142,8 @@ for k in range(N_obs):
 
 if fd.COMM_WORLD.rank == 0:
     u_e = np.stack((u1_e, u2_e), axis=-1)
-    u_sim_allobs_step = np.stack((u1_sim_obs_allobs_step,
-                                  u2_sim_obs_allobs_step), axis=-1)
+    u_sim_allobs_step = np.stack(
+        (u1_sim_obs_allobs_step, u2_sim_obs_allobs_step), axis=-1
+    )
     np.save("Velocity_ensemble.npy", u_e)
     np.save("Velocity simalated_all_time.npy", u_sim_allobs_step)

--- a/examples/stochastic_euler/generate_data.py
+++ b/examples/stochastic_euler/generate_data.py
@@ -17,11 +17,13 @@ x = fd.SpatialCoordinate(model.mesh)
 sin = fd.sin
 pi = fd.pi
 cos = fd.cos
-q0.interpolate(sin(8*pi*x[0])*sin(8*pi*x[1])
-               + 0.4*cos(6*pi*x[0])*cos(6*pi*x[1])
-               + 0.02*sin(2*pi*x[0])
-               + 0.02*sin(2*pi*x[1])
-               + 0.3*cos(10*pi*x[0])*cos(4*pi*x[1]))
+q0.interpolate(
+    sin(8 * pi * x[0]) * sin(8 * pi * x[1])
+    + 0.4 * cos(6 * pi * x[0]) * cos(6 * pi * x[1])
+    + 0.02 * sin(2 * pi * x[0])
+    + 0.02 * sin(2 * pi * x[1])
+    + 0.3 * cos(10 * pi * x[0]) * cos(4 * pi * x[1])
+)
 
 N_obs = 5
 
@@ -49,8 +51,8 @@ for i in range(N_obs):
     u1_true_all[i, :] = u[:, 0]
     u2_true_all[i, :] = u[:, 1]
 
-    u_1_noise = np.random.normal(0.0, 0.05, (n+1)**2)
-    u_2_noise = np.random.normal(0.0, 0.05, (n+1)**2)
+    u_1_noise = np.random.normal(0.0, 0.05, (n + 1) ** 2)
+    u_2_noise = np.random.normal(0.0, 0.05, (n + 1) ** 2)
     u1_obs = u[:, 0] + u_1_noise
     u2_obs = u[:, 1] + u_2_noise
     u1_obs_all[i, :] = u1_obs

--- a/examples/stochastic_euler/plot_tool.py
+++ b/examples/stochastic_euler/plot_tool.py
@@ -1,12 +1,12 @@
 import numpy as np
 import matplotlib.pyplot as plt
 
-u_e = np.load('Velocity_ensemble.npy')
-u_obs_alltime = np.load('Velocity simulated_all_time.npy')
+u_e = np.load("Velocity_ensemble.npy")
+u_obs_alltime = np.load("Velocity simulated_all_time.npy")
 n_ensemble = np.shape(u_e)[0]
 u_alltime = np.transpose(u_obs_alltime, (1, 0, 2, 3))
 
 xi = 21
 
-plt.plot(u_alltime[:, :, xi, 1], 'g-')
+plt.plot(u_alltime[:, :, xi, 1], "g-")
 plt.show()

--- a/nudging/__init__.py
+++ b/nudging/__init__.py
@@ -4,5 +4,7 @@ from nudging.pfilter import *  # noqa: F401, F403
 from nudging.resampling import *  # noqa: F401, F403
 from nudging.parallel_arrays import *  # noqa: F401, F403
 from nudging.diagnostics import *  # noqa: F401, F403
-from nudging.global_optimisation import ensemble_tao_solver, \
-    ParameterisedEnsembleReducedFunctional  # noqa: F401
+from nudging.global_optimisation import (
+    ensemble_tao_solver,
+    ParameterisedEnsembleReducedFunctional,
+)  # noqa: F401

--- a/nudging/diagnostics.py
+++ b/nudging/diagnostics.py
@@ -25,9 +25,9 @@ class base_diagnostic(object, metaclass=ABCMeta):
 
     def __init__(self, stage, ecomm, nensemble, dtype=None):
         self.stage = stage
-        self.shared_arr = SharedArray(partition=nensemble,
-                                      dtype=dtype,
-                                      comm=ecomm.ensemble_comm)
+        self.shared_arr = SharedArray(
+            partition=nensemble, dtype=dtype, comm=ecomm.ensemble_comm
+        )
         self.grank = ecomm.global_comm.rank
         self.N = nensemble[ecomm.ensemble_comm.rank]
         self.dtype = dtype
@@ -104,10 +104,15 @@ class base_diagnostic(object, metaclass=ABCMeta):
             self.values = []
 
 
-def compute_diagnostics(diagnostic_list, ensemble,
-                        descriptor, stage,
-                        other_data={}, run=None,
-                        new_ensemble=None):
+def compute_diagnostics(
+    diagnostic_list,
+    ensemble,
+    descriptor,
+    stage,
+    other_data={},
+    run=None,
+    new_ensemble=None,
+):
     """
     Compute all diagnostics in diagnostic_list labelled with stage
 

--- a/nudging/global_optimisation.py
+++ b/nudging/global_optimisation.py
@@ -2,7 +2,8 @@ import firedrake as fd
 from operator import mul
 from functools import reduce
 from pyadjoint.enlisting import Enlist
-from firedrake.petsc import PETSc, OptionsManager, flatten_parameters
+from firedrake.petsc import PETSc, flatten_parameters
+from petsctools.options import OptionsManager
 import firedrake.adjoint as fadj
 import logging
 

--- a/nudging/global_optimisation.py
+++ b/nudging/global_optimisation.py
@@ -34,8 +34,7 @@ class ensemble_petsc_interface:
         for x in X:
             fn = x.tape_value()
             if not isinstance(fn, fd.Function):
-                raise NotImplementedError(
-                    "Controls must be Firedrake Functions")
+                raise NotImplementedError("Controls must be Firedrake Functions")
             function_spaces.append(fn.ufl_function_space())
         # This will flatten mixed spaces into one mixed space
         mixed_function_space = reduce(mul, function_spaces)
@@ -51,9 +50,9 @@ class ensemble_petsc_interface:
         self.w = w
         gcomm = self.ensemble.global_comm
         with w.dat.vec as fvec:
-            self.vec = PETSc.Vec().createWithArray(fvec.array,
-                                                   size=self.sizes,
-                                                   comm=gcomm)
+            self.vec = PETSc.Vec().createWithArray(
+                fvec.array, size=self.sizes, comm=gcomm
+            )
 
     def vec2list(self, vec):
         """
@@ -108,8 +107,7 @@ class ensemble_petsc_interface:
 
 
 class ParameterisedEnsembleReducedFunctional:
-    def __init__(self, Js, Controls, Parameters, ensemble,
-                 gather_functional):
+    def __init__(self, Js, Controls, Parameters, ensemble, gather_functional):
         self.controls = Controls
         full_Controls = Controls + Parameters
         self.Parameters = []
@@ -117,9 +115,13 @@ class ParameterisedEnsembleReducedFunctional:
             self.Parameters.append(parameter.tape_value())
         derivative_components = [i for i in range(len(Controls))]
         self.rf = fadj.EnsembleReducedFunctional(
-            Js, full_Controls, ensemble, scatter_control=False,
+            Js,
+            full_Controls,
+            ensemble,
+            scatter_control=False,
             gather_functional=gather_functional,
-            derivative_components=derivative_components)
+            derivative_components=derivative_components,
+        )
         self.derivative_components = derivative_components
 
     def update_parameters(self, Parameters):
@@ -138,8 +140,7 @@ class ParameterisedEnsembleReducedFunctional:
 
 
 class ensemble_tao_solver:
-    def __init__(self, Jhat, ensemble,
-                 solver_parameters, options_prefix="ensemble"):
+    def __init__(self, Jhat, ensemble, solver_parameters, options_prefix="ensemble"):
         """
         Jhat - firedrake.EnsembleReducedFunctional
         ensemble - Firedrake.Ensemble ensemble communication object
@@ -170,21 +171,20 @@ class ensemble_tao_solver:
             def mult(self, mat, X, Y):
                 # abusing vec2list side effect of copying to interface.w
                 self.interface.vec2list(X)
-                fd.assemble(fd.inner(self.v, self.interface.w)*fd.dx,
-                            tensor=self.ycofunc)
+                fd.assemble(
+                    fd.inner(self.v, self.interface.w) * fd.dx, tensor=self.ycofunc
+                )
                 with self.ycofunc.dat.vec_ro as yvec:
                     yvec.copy(Y)
 
         sizes = interface.sizes
-        M = PETSc.Mat().createPython([sizes, sizes],
-                                     comm=ensemble.global_comm)
+        M = PETSc.Mat().createPython([sizes, sizes], comm=ensemble.global_comm)
         M.setPythonContext(inner_mat(interface))
         M.setUp()
         tao.setGradientNorm(M)
 
         flat_solver_parameters = flatten_parameters(solver_parameters)
-        options = OptionsManager(flat_solver_parameters,
-                                 options_prefix)
+        options = OptionsManager(flat_solver_parameters, options_prefix)
         tao.setOptionsPrefix(options.options_prefix)
         options.set_from_options(tao)
 

--- a/nudging/models/linear_scalar_sde.py
+++ b/nudging/models/linear_scalar_sde.py
@@ -37,7 +37,7 @@ class LSDEModel(base_model):
 
     def run(self, X0, X1, s=None):
         if not s:
-            s = [1.0]*self.nsteps
+            s = [1.0] * self.nsteps
         for i in range(len(X0)):
             self.X[i].assign(X0[i])
 
@@ -50,14 +50,16 @@ class LSDEModel(base_model):
         D = self.D
 
         if self.lambdas:
-            self.Lambda.assign(0.)
+            self.Lambda.assign(0.0)
         for step in range(self.nsteps):
             if self.lambdas:
-                self.Lambda.assign(self.Lambda + s[step]*self.X[self.nsteps+step+1])
-                dW.assign(self.X[step+1] + dt**0.5*self.Lambda)
+                self.Lambda.assign(
+                    self.Lambda + s[step] * self.X[self.nsteps + step + 1]
+                )
+                dW.assign(self.X[step + 1] + dt**0.5 * self.Lambda)
             else:
-                dW.assign(self.X[step+1])
-            u.assign(u*(1 - dt*A/2) + D*dt**0.5*dW)/(1 + dt*A/2)
+                dW.assign(self.X[step + 1])
+            u.assign(u * (1 - dt * A / 2) + D * dt**0.5 * dW) / (1 + dt * A / 2)
         X1[0].assign(self.u)
 
     def controls(self):
@@ -88,10 +90,9 @@ class LSDEModel(base_model):
         count = 0
         for i in range(self.nsteps):
             count += 1
-            X[count].assign(c1*X[count] + c2*rg.normal(
-                self.V, 0., 1.))
+            X[count].assign(c1 * X[count] + c2 * rg.normal(self.V, 0.0, 1.0))
             if g:
-                X[count] += gscale*g[count]
+                X[count] += gscale * g[count]
 
     def lambda_functional(self, s=None):
         nsteps = self.nsteps
@@ -99,19 +100,21 @@ class LSDEModel(base_model):
         dx = fd.dx
         cv = 1.0  # should be fd.CellVolume(self.mesh)
 
-        self.Lambda.assign(0.)
+        self.Lambda.assign(0.0)
         for step in range(nsteps):
             # X[0] is the model state
             # X[1], .., X[nsteps] are the dWs
             # X[nsteps+1], .., X[2*nsteps] are the lambdas
             if s:
-                self.Lambda.assign(self.Lambda + s[step]*self.X[nsteps + 1 + step])
+                self.Lambda.assign(self.Lambda + s[step] * self.X[nsteps + 1 + step])
             else:
                 self.Lambda.assign(self.Lambda + self.X[nsteps + 1 + step])
             lambda_step = self.Lambda
             dW_step = self.X[1 + step]
-            dlfunc = fd.assemble((1/cv)*lambda_step**2*dt/2*dx
-                                - (1/cv)*lambda_step*dW_step*dt**0.5*dx)
+            dlfunc = fd.assemble(
+                (1 / cv) * lambda_step**2 * dt / 2 * dx
+                - (1 / cv) * lambda_step * dW_step * dt**0.5 * dx
+            )
             if step == 0:
                 lfunc = dlfunc
             else:

--- a/nudging/models/linear_scalar_sde.py
+++ b/nudging/models/linear_scalar_sde.py
@@ -2,6 +2,9 @@ import firedrake as fd
 import firedrake.adjoint as fadj
 from nudging import base_model
 from pyop2.mpi import MPI
+from firedrake.petsc import PETSc
+
+Print = PETSc.Sys.Print
 
 
 class LSDEModel(base_model):
@@ -19,12 +22,18 @@ class LSDEModel(base_model):
         self.seed = seed
 
     def setup(self, comm=MPI.COMM_WORLD):
+        """
+        Sets up the mesh and function spaces for the solver.
+        Sets up the Vertex-only mesh for observations.
+        """
         self.mesh = fd.UnitIntervalMesh(1, comm=comm)
 
-        self.R = fd.FunctionSpace(self.mesh, "R", 0)
-        self.V = fd.FunctionSpace(self.mesh, "DG", 0)
-        self.u = fd.Function(self.V)
-        self.dW = fd.Function(self.V)
+        self.R = fd.FunctionSpace(
+            self.mesh, "R", 0
+        )  # An R space function to deal with uniform random numbers for resampling
+        self.V = fd.FunctionSpace(self.mesh, "DG", 0)  # FE Function space
+        self.u = fd.Function(self.V)  # Solution function
+        self.dW = fd.Function(self.V)  # Brownian increment
         self.Lambda = fd.Function(self.V)
 
         # state for controls
@@ -33,9 +42,11 @@ class LSDEModel(base_model):
         # vertex only mesh for observations
         x_obs_list = [[0.2]]
         self.VOM = fd.VertexOnlyMesh(self.mesh, x_obs_list)
-        self.VVOM = fd.FunctionSpace(self.VOM, "DG", 0)
+        self.VVOM = fd.FunctionSpace(self.VOM, "DG", 0)  # Observation function space
 
     def run(self, X0, X1, s=None):
+        # X0 is the ensemble state. Length 2nsteps+1 if lambdas else nsteps+1
+        # X1 is the new ensemble state after running the model. Length 2nsteps+1 if lambdas else nsteps+1
         if not s:
             s = [1.0] * self.nsteps
         for i in range(len(X0)):

--- a/nudging/models/stochastic_Camassa_Holm.py
+++ b/nudging/models/stochastic_Camassa_Holm.py
@@ -5,8 +5,18 @@ import numpy as np
 
 
 class Camsholm(base_model):
-    def __init__(self, n, nsteps, xpoints, seed=12353, lambdas=False,
-                 dt=0.025, alpha=1.0, mu=0.01, salt=False):
+    def __init__(
+        self,
+        n,
+        nsteps,
+        xpoints,
+        seed=12353,
+        lambdas=False,
+        dt=0.025,
+        alpha=1.0,
+        mu=0.01,
+        salt=False,
+    ):
 
         self.n = n
         self.nsteps = nsteps
@@ -20,7 +30,7 @@ class Camsholm(base_model):
 
     def setup(self, comm=MPI.COMM_WORLD):
         self.mesh = fd.PeriodicIntervalMesh(self.n, 40.0, comm=comm)
-        x, = fd.SpatialCoordinate(self.mesh)
+        (x,) = fd.SpatialCoordinate(self.mesh)
 
         self.V = fd.FunctionSpace(self.mesh, "CG", 1)
         V = fd.FunctionSpace(self.mesh, "CG", 1)
@@ -29,26 +39,25 @@ class Camsholm(base_model):
         m0, u0 = self.w0.split()
         One = fd.Function(V).assign(1.0)
         dx = fd.dx
-        self.Area = fd.assemble(One*dx)
+        self.Area = fd.assemble(One * dx)
 
         # Solver for the initial condition for m.
         alphasq = self.alpha**2
         p = fd.TestFunction(V)
         m = fd.TrialFunction(V)
 
-        am = p*m*dx
-        Lm = (p*u0 + alphasq*p.dx(0)*u0.dx(0))*dx
+        am = p * m * dx
+        Lm = (p * u0 + alphasq * p.dx(0) * u0.dx(0)) * dx
         mprob = fd.LinearVariationalProblem(am, Lm, m0)
-        sp = {'ksp_type': 'preonly', 'pc_type': 'lu'}
-        self.msolve = fd.LinearVariationalSolver(mprob,
-                                                 solver_parameters=sp)
+        sp = {"ksp_type": "preonly", "pc_type": "lu"}
+        self.msolve = fd.LinearVariationalSolver(mprob, solver_parameters=sp)
 
         # Build the weak form of the timestepping algorithm.
         p, q = fd.TestFunctions(self.W)
         self.w1 = fd.Function(self.W)
         self.w1.assign(self.w0)
-        m1, u1 = fd.split(self.w1)   # for n+1 th time
-        m0, u0 = fd.split(self.w0)   # for n th time
+        m1, u1 = fd.split(self.w1)  # for n+1 th time
+        m0, u0 = fd.split(self.w0)  # for n th time
 
         # Setup noise term using Matern formula
         self.W_F = fd.FunctionSpace(self.mesh, "DG", 0)
@@ -57,49 +66,47 @@ class Camsholm(base_model):
         du = fd.TrialFunction(V)
 
         cell_area = fd.CellVolume(self.mesh)
-        alpha_w = (1/cell_area**0.5)
+        alpha_w = 1 / cell_area**0.5
         kappa_inv_sq = fd.Constant(1.0)
 
         dU_1 = fd.Function(V)
         dU_2 = fd.Function(V)
         dU_3 = fd.Function(V)
-        a_w = (dphi*du + kappa_inv_sq*dphi.dx(0)*du.dx(0))*dx
-        L_w0 = alpha_w*dphi*self.dW*dx
+        a_w = (dphi * du + kappa_inv_sq * dphi.dx(0) * du.dx(0)) * dx
+        L_w0 = alpha_w * dphi * self.dW * dx
         w_prob0 = fd.LinearVariationalProblem(a_w, L_w0, dU_1)
-        self.wsolver0 = fd.LinearVariationalSolver(w_prob0,
-                                                   solver_parameters=sp)
-        L_w1 = dphi*dU_1*dx
+        self.wsolver0 = fd.LinearVariationalSolver(w_prob0, solver_parameters=sp)
+        L_w1 = dphi * dU_1 * dx
         w_prob1 = fd.LinearVariationalProblem(a_w, L_w1, dU_2)
-        self.wsolver1 = fd.LinearVariationalSolver(w_prob1,
-                                                   solver_parameters=sp)
-        L_w = dphi*dU_2*dx
+        self.wsolver1 = fd.LinearVariationalSolver(w_prob1, solver_parameters=sp)
+        L_w = dphi * dU_2 * dx
         w_prob = fd.LinearVariationalProblem(a_w, L_w, dU_3)
-        self.wsolver = fd.LinearVariationalSolver(w_prob,
-                                                  solver_parameters=sp)
+        self.wsolver = fd.LinearVariationalSolver(w_prob, solver_parameters=sp)
 
         # finite element linear functional
         Dt = self.dt
-        mh = 0.5*(m1 + m0)
-        uh = 0.5*(u1 + u0)
+        mh = 0.5 * (m1 + m0)
+        uh = 0.5 * (u1 + u0)
 
         if self.salt:
             # SALT noise
-            v = uh*Dt+dU_3*Dt**0.5
+            v = uh * Dt + dU_3 * Dt**0.5
         else:
             # additive noise
-            v = uh*Dt
-        L = ((q*u1 + alphasq*q.dx(0)*u1.dx(0) - q*m1)*dx
-             + (p*(m1-m0) + (p*v.dx(0)*mh - p.dx(0)*v*mh)
-                + self.mu*Dt*p.dx(0)*mh.dx(0))*dx)
+            v = uh * Dt
+        L = (q * u1 + alphasq * q.dx(0) * u1.dx(0) - q * m1) * dx + (
+            p * (m1 - m0)
+            + (p * v.dx(0) * mh - p.dx(0) * v * mh)
+            + self.mu * Dt * p.dx(0) * mh.dx(0)
+        ) * dx
 
         if not self.salt:
-            L += p*dU_3*Dt**0.5*dx
+            L += p * dU_3 * Dt**0.5 * dx
 
         # timestepping solver
         uprob = fd.NonlinearVariationalProblem(L, self.w1)
-        sp = {'mat_type': 'aij', 'ksp_type': 'preonly', 'pc_type': 'lu'}
-        self.usolver = fd.NonlinearVariationalSolver(uprob,
-                                                     solver_parameters=sp)
+        sp = {"mat_type": "aij", "ksp_type": "preonly", "pc_type": "lu"}
+        self.usolver = fd.NonlinearVariationalSolver(uprob, solver_parameters=sp)
 
         # state for controls
         self.X = self.allocate()
@@ -126,9 +133,9 @@ class Camsholm(base_model):
         # do the timestepping
         for step in range(self.nsteps):
             # get noise variables and lambdas
-            self.dW.assign(self.X[step+1])
+            self.dW.assign(self.X[step + 1])
             if self.lambdas:
-                self.dW += self.X[step+1+self.nsteps]*(self.dt)**0.5
+                self.dW += self.X[step + 1 + self.nsteps] * (self.dt) ** 0.5
             # solve  dW --> dU0 --> dU1 --> dU
             self.wsolver0.solve()
             self.wsolver1.solve()
@@ -169,10 +176,9 @@ class Camsholm(base_model):
         count = 0
         for i in range(self.nsteps):
             count += 1
-            X[count].assign(c1*X[count] + c2*rg.normal(
-                self.W_F, 0., 1.))
+            X[count].assign(c1 * X[count] + c2 * rg.normal(self.W_F, 0.0, 1.0))
             if g:
-                X[count] += gscale*g[count]
+                X[count] += gscale * g[count]
 
     def lambda_functional(self):
         nsteps = self.nsteps
@@ -192,8 +198,10 @@ class Camsholm(base_model):
             lambda_step = self.X[nsteps + 1 + step]
             dW_step = self.X[1 + step]
             cv = fd.CellVolume(self.mesh)
-            dlfunc = fd.assemble((1/cv)*lambda_step**2*dt/2*dx
-                                 - (1/cv)*lambda_step*dW_step*dt**0.5*dx)
+            dlfunc = fd.assemble(
+                (1 / cv) * lambda_step**2 * dt / 2 * dx
+                - (1 / cv) * lambda_step * dW_step * dt**0.5 * dx
+            )
             if step == 0:
                 lfunc = dlfunc
             else:

--- a/nudging/models/stochastic_KS.py
+++ b/nudging/models/stochastic_KS.py
@@ -5,24 +5,33 @@ import numpy as np
 
 
 class KS(base_model):
-    def __init__(self, nsteps, xpoints, n=100, seed=12353, lambdas=False,
-                 dt=0.01, nu=0.02923, dc=0.01, L=10.):
+    def __init__(
+        self,
+        nsteps,
+        xpoints,
+        n=100,
+        seed=12353,
+        lambdas=False,
+        dt=0.01,
+        nu=0.02923,
+        dc=0.01,
+        L=10.0,
+    ):
 
         self.n = n
         self.nsteps = nsteps
         self.dt = dt
         self.seed = seed
-        self.nu = nu #  viscosity
-        self.dc = dc #  noise coefficient
-        self.L = L #  domain width
+        self.nu = nu  #  viscosity
+        self.dc = dc  #  noise coefficient
+        self.L = L  #  domain width
         self.xpoints = xpoints
         self.lambdas = lambdas  # include lambdas in allocate
 
     def setup(self, comm=MPI.COMM_WORLD):
-        mesh = fd.PeriodicIntervalMesh(self.n, self.L,
-                                           comm=comm, name="ksmesh")
+        mesh = fd.PeriodicIntervalMesh(self.n, self.L, comm=comm, name="ksmesh")
         self.mesh = mesh
-        x, = fd.SpatialCoordinate(mesh)
+        (x,) = fd.SpatialCoordinate(mesh)
 
         V = fd.FunctionSpace(mesh, "Hermite", 3)
         self.V = V
@@ -31,47 +40,44 @@ class KS(base_model):
         self.un = un
         unp1 = fd.Function(V)
         self.unp1 = unp1
-        uh = (un + unp1)/2
-        
+        uh = (un + unp1) / 2
+
         v = fd.TestFunction(V)
-        
+
         dt = 0.01
         dT = fd.Constant(dt)
 
         self.DG0 = fd.FunctionSpace(mesh, "DG", 0)
         dW = fd.Function(self.DG0)
         self.dW = dW
-        alpha = fd.Constant(1.0) # viscosity
-        beta = fd.Constant(0.02923) # hyperviscosity
-        gamma = fd.Constant(1.) # advection
-        dc = fd.Constant(0.001) # diffusion coefficient for noise
+        alpha = fd.Constant(1.0)  # viscosity
+        beta = fd.Constant(0.02923)  # hyperviscosity
+        gamma = fd.Constant(1.0)  # advection
+        dc = fd.Constant(0.001)  # diffusion coefficient for noise
         area = fd.CellVolume(mesh)
         dx = fd.dx
 
         eqn = (
-            v*(unp1 - un)*dx
-            - dT*alpha*v.dx(0)*uh.dx(0)*dx
-            + dT*beta*(
-                v.dx(0).dx(0)*uh.dx(0).dx(0)*dx
-            )
-            - dT*gamma*0.5*v.dx(0)*uh*uh*dx
-            - (dT/area)**0.5*dc*dW*v*dx
+            v * (unp1 - un) * dx
+            - dT * alpha * v.dx(0) * uh.dx(0) * dx
+            + dT * beta * (v.dx(0).dx(0) * uh.dx(0).dx(0) * dx)
+            - dT * gamma * 0.5 * v.dx(0) * uh * uh * dx
+            - (dT / area) ** 0.5 * dc * dW * v * dx
         )
 
         params = {
             "snes_atol": 1.0e-50,
             "snes_rtol": 1.0e-6,
             "snes_stol": 1.0e-50,
-            "ksp_type":"preonly",
-            "pc_type":"lu"
+            "ksp_type": "preonly",
+            "pc_type": "lu",
         }
 
-        #make the solver
+        # make the solver
         KSProb = fd.NonlinearVariationalProblem(eqn, unp1)
-        self.KSSolver = fd.NonlinearVariationalSolver(KSProb,
-                                                      solver_parameters=params)
+        self.KSSolver = fd.NonlinearVariationalSolver(KSProb, solver_parameters=params)
 
-        #stuff for interpolation to VOM
+        # stuff for interpolation to VOM
         CG3 = fd.FunctionSpace(mesh, "CG", 3)
         self.CG3 = CG3
         self.uout = fd.Function(CG3)
@@ -98,9 +104,9 @@ class KS(base_model):
         # do the timestepping
         for step in range(self.nsteps):
             # get noise variables and lambdas
-            self.dW.assign(self.X[step+1])
+            self.dW.assign(self.X[step + 1])
             if self.lambdas:
-                self.dW += self.X[step+1+self.nsteps]*(self.dt)**0.5
+                self.dW += self.X[step + 1 + self.nsteps] * (self.dt) ** 0.5
             # advance in time
             self.KSSolver.solve()
             # copy output to input
@@ -137,10 +143,9 @@ class KS(base_model):
         count = 0
         for i in range(self.nsteps):
             count += 1
-            X[count].assign(c1*X[count] + c2*rg.normal(
-                self.DG0, 0., 1.))
+            X[count].assign(c1 * X[count] + c2 * rg.normal(self.DG0, 0.0, 1.0))
             if g:
-                X[count] += gscale*g[count]
+                X[count] += gscale * g[count]
 
     def lambda_functional(self):
         nsteps = self.nsteps
@@ -160,8 +165,10 @@ class KS(base_model):
             lambda_step = self.X[nsteps + 1 + step]
             dW_step = self.X[1 + step]
             cv = fd.CellVolume(mesh)
-            dlfunc = fd.assemble((1/cv)*lambda_step**2*dt/2*dx
-                                 - (1/cv)*lambda_step*dW_step*dt**0.5*dx)
+            dlfunc = fd.assemble(
+                (1 / cv) * lambda_step**2 * dt / 2 * dx
+                - (1 / cv) * lambda_step * dW_step * dt**0.5 * dx
+            )
             if step == 0:
                 lfunc = dlfunc
             else:

--- a/nudging/models/stochastic_KS_CIP.py
+++ b/nudging/models/stochastic_KS_CIP.py
@@ -5,39 +5,50 @@ import numpy as np
 
 
 class KS_CIP(base_model):
-    def __init__(self, nsteps, xpoints, n=100, seed=12353,  mesh=False,lambdas=False,
-                 dt=0.01, nu=0.02923, dc=0.01, L=10.):
+    def __init__(
+        self,
+        nsteps,
+        xpoints,
+        n=100,
+        seed=12353,
+        mesh=False,
+        lambdas=False,
+        dt=0.01,
+        nu=0.02923,
+        dc=0.01,
+        L=10.0,
+    ):
 
         self.n = n
         self.nsteps = nsteps
         self.dt = dt
         self.seed = seed
-        self.nu = nu #  viscosity
-        self.dc = dc #  noise coefficient
-        self.L = L #  domain width
+        self.nu = nu  #  viscosity
+        self.dc = dc  #  noise coefficient
+        self.L = L  #  domain width
         self.mesh = mesh
         self.xpoints = xpoints
         self.lambdas = lambdas  # include lambdas in allocate
 
     def setup(self, comm=MPI.COMM_WORLD):
         if not self.mesh:
-            self.mesh = fd.PeriodicIntervalMesh(self.n, self.L,
-                                           comm=comm, name="ksmesh")
-        #self.mesh = mesh
-        x, = fd.SpatialCoordinate(self.mesh)
+            self.mesh = fd.PeriodicIntervalMesh(
+                self.n, self.L, comm=comm, name="ksmesh"
+            )
+        # self.mesh = mesh
+        (x,) = fd.SpatialCoordinate(self.mesh)
 
         self.V = fd.FunctionSpace(self.mesh, "CG", 2)
-        self.Vdg = fd.FunctionSpace(self.mesh, "DG", 1) # for VTK output 
-       
+        self.Vdg = fd.FunctionSpace(self.mesh, "DG", 1)  # for VTK output
 
         un = fd.Function(self.V)
         self.un = un
         unp1 = fd.Function(self.V)
         self.unp1 = unp1
-        uh = (un + unp1)/2 # midpoint
-        
+        uh = (un + unp1) / 2  # midpoint
+
         v = fd.TestFunction(self.V)
-        
+
         dT = fd.Constant(self.dt)
 
         # Setup noise term and lambdas
@@ -45,13 +56,13 @@ class KS_CIP(base_model):
         self.dW = fd.Function(self.W_F)
         self.Lambda = fd.Function(self.W_F)
 
-        # model coefficient 
-        alpha = fd.Constant(1.1) # viscosity
-        beta = fd.Constant(0.02923) # hyperviscosity
-        gamma = fd.Constant(1.) # advection
+        # model coefficient
+        alpha = fd.Constant(1.1)  # viscosity
+        beta = fd.Constant(0.02923)  # hyperviscosity
+        gamma = fd.Constant(1.0)  # advection
 
-        eta = fd.Constant(5.) # penalty term
-        area = fd.Constant(self.L/self.n)
+        eta = fd.Constant(5.0)  # penalty term
+        area = fd.Constant(self.L / self.n)
         dx = fd.dx
         dS = fd.dS
         avg = fd.avg
@@ -59,37 +70,38 @@ class KS_CIP(base_model):
 
         def a(u, v):
             h = area
-            eqn = v.dx(0).dx(0)*u.dx(0).dx(0)*dx # diffusion
-            eqn += avg(u.dx(0).dx(0))*jump(v.dx(0))*dS # <avg(u_xx), jump(v_x)>
-            eqn += avg(v.dx(0).dx(0))*jump(u.dx(0))*dS # <avg(v_xx), jump(u_x)>
-            eqn += eta/h*jump(v.dx(0))*jump(u.dx(0))*dS # eth/h*<jump(v_x), jump(u_x)>
+            eqn = v.dx(0).dx(0) * u.dx(0).dx(0) * dx  # diffusion
+            eqn += avg(u.dx(0).dx(0)) * jump(v.dx(0)) * dS  # <avg(u_xx), jump(v_x)>
+            eqn += avg(v.dx(0).dx(0)) * jump(u.dx(0)) * dS  # <avg(v_xx), jump(u_x)>
+            eqn += (
+                eta / h * jump(v.dx(0)) * jump(u.dx(0)) * dS
+            )  # eth/h*<jump(v_x), jump(u_x)>
             return eqn
 
         eqn = (
-            v*(unp1 - un)*dx
-            - dT*alpha*v.dx(0)*uh.dx(0)*dx
-            + a(dT*beta*uh, v)
-            - dT*gamma*0.5*v.dx(0)*uh*uh*dx
-            - (dT/area)**0.5*self.dc*self.dW*v*dx
-            )
+            v * (unp1 - un) * dx
+            - dT * alpha * v.dx(0) * uh.dx(0) * dx
+            + a(dT * beta * uh, v)
+            - dT * gamma * 0.5 * v.dx(0) * uh * uh * dx
+            - (dT / area) ** 0.5 * self.dc * self.dW * v * dx
+        )
 
         linear_snes_params = {
-                'lag_preconditioner': 5,
-                'lag_preconditioner_persists': None,
-                            }
+            "lag_preconditioner": 5,
+            "lag_preconditioner_persists": None,
+        }
         params = {
-            'snes': linear_snes_params,
+            "snes": linear_snes_params,
             "snes_atol": 1.0e-50,
             "snes_rtol": 1.0e-6,
             "snes_stol": 1.0e-50,
-            "ksp_type":"gmres",
-            "pc_type":"lu"
+            "ksp_type": "gmres",
+            "pc_type": "lu",
         }
 
-        #make the solver
+        # make the solver
         KSProb = fd.NonlinearVariationalProblem(eqn, unp1)
-        self.KSSolver = fd.NonlinearVariationalSolver(KSProb,
-                                                      solver_parameters=params)
+        self.KSSolver = fd.NonlinearVariationalSolver(KSProb, solver_parameters=params)
 
         # state for controls
         self.X = self.allocate()
@@ -104,7 +116,7 @@ class KS_CIP(base_model):
 
     def run(self, X0, X1, s=None):
         if not s:
-            s = [1.0]*self.nsteps
+            s = [1.0] * self.nsteps
         # copy input into model variables for taping
         for i in range(len(X0)):
             self.X[i].assign(X0[i])
@@ -114,15 +126,17 @@ class KS_CIP(base_model):
         self.unp1.assign(self.un)
 
         if self.lambdas:
-            self.Lambda.assign(0.)
+            self.Lambda.assign(0.0)
         # do the timestepping
         for step in range(self.nsteps):
             # get noise variables and lambdas
             if self.lambdas:
-                self.Lambda.assign(self.Lambda + s[step]*self.X[self.nsteps+step+1])
-                self.dW.assign(self.X[step+1] + self.dt**0.5*self.Lambda)
+                self.Lambda.assign(
+                    self.Lambda + s[step] * self.X[self.nsteps + step + 1]
+                )
+                self.dW.assign(self.X[step + 1] + self.dt**0.5 * self.Lambda)
             else:
-                self.dW.assign(self.X[step+1])
+                self.dW.assign(self.X[step + 1])
             # advance in time
             self.KSSolver.solve()
             # copy output to input
@@ -158,30 +172,31 @@ class KS_CIP(base_model):
         count = 0
         for i in range(self.nsteps):
             count += 1
-            X[count].assign(c1*X[count] + c2*rg.normal(
-                self.W_F, 0., 1.))
+            X[count].assign(c1 * X[count] + c2 * rg.normal(self.W_F, 0.0, 1.0))
             if g:
-                X[count] += gscale*g[count]
+                X[count] += gscale * g[count]
 
     def lambda_functional(self, s=None):
         nsteps = self.nsteps
         dt = self.dt
         dx = fd.dx
-        cv = fd.Constant(self.L/self.n)
+        cv = fd.Constant(self.L / self.n)
 
-        self.Lambda.assign(0.)
+        self.Lambda.assign(0.0)
         for step in range(nsteps):
             # X[0] is the model state
             # X[1], .., X[nsteps] are the dWs
             # X[nsteps+1], .., X[2*nsteps] are the lambdas
             if s:
-                self.Lambda.assign(self.Lambda + s[step]*self.X[nsteps + 1 + step])
+                self.Lambda.assign(self.Lambda + s[step] * self.X[nsteps + 1 + step])
             else:
                 self.Lambda.assign(self.Lambda + self.X[nsteps + 1 + step])
             lambda_step = self.Lambda
             dW_step = self.X[1 + step]
-            dlfunc = fd.assemble((1/cv)*lambda_step**2*dt/2*dx
-                                - (1/cv)*lambda_step*dW_step*dt**0.5*dx)
+            dlfunc = fd.assemble(
+                (1 / cv) * lambda_step**2 * dt / 2 * dx
+                - (1 / cv) * lambda_step * dW_step * dt**0.5 * dx
+            )
             if step == 0:
                 lfunc = dlfunc
             else:

--- a/nudging/models/stochastic_euler.py
+++ b/nudging/models/stochastic_euler.py
@@ -14,13 +14,17 @@ class Euler_SD(base_model):
 
     def setup(self, comm=MPI.COMM_WORLD):
         r = 0.01
-        self.Lx = 2.0*fd.pi  # Zonal length
-        self.Ly = 2.0*fd.pi  # Meridonal length
-        self.mesh = fd.PeriodicRectangleMesh(self.n, self.n,
-                                             self.Lx, self.Ly,
-                                             direction="x",
-                                             quadrilateral=True,
-                                             comm=comm)
+        self.Lx = 2.0 * fd.pi  # Zonal length
+        self.Ly = 2.0 * fd.pi  # Meridonal length
+        self.mesh = fd.PeriodicRectangleMesh(
+            self.n,
+            self.n,
+            self.Lx,
+            self.Ly,
+            direction="x",
+            quadrilateral=True,
+            comm=comm,
+        )
         # FE spaces
         self.Vcg = fd.FunctionSpace(self.mesh, "CG", 1)  # Streamfunctions
         self.Vdg = fd.FunctionSpace(self.mesh, "DQ", 1)  # PV space
@@ -37,19 +41,17 @@ class Euler_SD(base_model):
 
         # Build the weak form for the inversion
         from firedrake import inner, grad, dx
-        Apsi = (inner(grad(psi), grad(phi)) + psi*phi)*dx
+
+        Apsi = (inner(grad(psi), grad(phi)) + psi * phi) * dx
         Lpsi = -self.q1 * phi * dx
 
         bc1 = fd.DirichletBC(self.Vcg, 0.0, (1, 2))
 
-        psi_problem = fd.LinearVariationalProblem(Apsi, Lpsi,
-                                                  self.psi0,
-                                                  bcs=bc1,
-                                                  constant_jacobian=True)
-        sp = {"ksp_type": "cg", "pc_type": "lu",
-              "pc_factor_mat_solver_type": "mumps"}
-        self.psi_solver = fd.LinearVariationalSolver(psi_problem,
-                                                     solver_parameters=sp)
+        psi_problem = fd.LinearVariationalProblem(
+            Apsi, Lpsi, self.psi0, bcs=bc1, constant_jacobian=True
+        )
+        sp = {"ksp_type": "cg", "pc_type": "lu", "pc_factor_mat_solver_type": "mumps"}
+        self.psi_solver = fd.LinearVariationalSolver(psi_problem, solver_parameters=sp)
         self.W_F = fd.FunctionSpace(self.mesh, "DG", 0)
         self.dW = fd.Function(self.W_F)
 
@@ -60,26 +62,25 @@ class Euler_SD(base_model):
         # to store noise data
         du_w = fd.Function(self.Vcg)
 
-        bcs_dw = fd.DirichletBC(self.Vcg,  fd.zero(), ("on_boundary"))
-        a_dW = inner(grad(dw), grad(dW_phi))*dx + dw*dW_phi*dx
-        L_dW = self.dW*dW_phi*dx
+        bcs_dw = fd.DirichletBC(self.Vcg, fd.zero(), ("on_boundary"))
+        a_dW = inner(grad(dw), grad(dW_phi)) * dx + dw * dW_phi * dx
+        L_dW = self.dW * dW_phi * dx
 
-        dW_problem = fd.LinearVariationalProblem(a_dW, L_dW, du_w,
-                                                 bcs=bcs_dw)
-        self.dW_solver = fd.LinearVariationalSolver(dW_problem,
-                                                    solver_parameters=sp)
+        dW_problem = fd.LinearVariationalProblem(a_dW, L_dW, du_w, bcs=bcs_dw)
+        self.dW_solver = fd.LinearVariationalSolver(dW_problem, solver_parameters=sp)
 
         # Add noise with stream function to get stochastic velocity
         from firedrake import dot, jump, as_vector
-        psi_mod = self.psi0+du_w
+
+        psi_mod = self.psi0 + du_w
 
         def gradperp(u):
             return as_vector((-u.dx(1), u.dx(0)))
+
         self.gradperp = gradperp
         # upwinding terms
         n_F = fd.FacetNormal(self.mesh)
-        un = 0.5 * (dot(gradperp(psi_mod), n_F) +
-                    abs(dot(gradperp(psi_mod), n_F)))
+        un = 0.5 * (dot(gradperp(psi_mod), n_F) + abs(dot(gradperp(psi_mod), n_F)))
 
         q = fd.TrialFunction(self.Vdg)
         p = fd.TestFunction(self.Vdg)
@@ -87,26 +88,22 @@ class Euler_SD(base_model):
 
         # timestepping equation
         from firedrake import dS
-        a_mass = p*q*dx
-        a_int = (dot(grad(p), -q*gradperp(psi_mod)) - p*(Q-r*q)) * dx
+
+        a_mass = p * q * dx
+        a_int = (dot(grad(p), -q * gradperp(psi_mod)) - p * (Q - r * q)) * dx
         a_flux = (dot(jump(p), un("+") * q("+") - un("-") * q("-"))) * dS
         arhs = a_mass - self.dt * (a_int + a_flux)
 
-        q_prob = fd.LinearVariationalProblem(a_mass,
-                                             fd.action(arhs, self.q1),
-                                             self.dq1)
-        dgsp = {"ksp_type": "preonly",
-                "pc_type": "bjacobi",
-                "sub_pc_type": "ilu"}
-        self.q_solver = fd.LinearVariationalSolver(q_prob,
-                                                   solver_parameters=dgsp)
+        q_prob = fd.LinearVariationalProblem(a_mass, fd.action(arhs, self.q1), self.dq1)
+        dgsp = {"ksp_type": "preonly", "pc_type": "bjacobi", "sub_pc_type": "ilu"}
+        self.q_solver = fd.LinearVariationalSolver(q_prob, solver_parameters=dgsp)
 
         # internal state for controls
         self.X = self.allocate()
 
         # observations
-        x_point = np.linspace(0.0, self.Lx, self.n+1)
-        y_point = np.linspace(0.0, self.Ly, self.n+1)
+        x_point = np.linspace(0.0, self.Lx, self.n + 1)
+        y_point = np.linspace(0.0, self.Ly, self.n + 1)
         xv, yv = np.meshgrid(x_point, y_point)
         x_obs_list = np.vstack([xv.ravel(), yv.ravel()]).T.tolist()
         VOM = fd.VertexOnlyMesh(self.mesh, x_obs_list)
@@ -119,9 +116,9 @@ class Euler_SD(base_model):
         self.q0.assign(self.X[0])
         for step in range(self.nsteps):
             # compute the noise term
-            self.dW.assign(self.X[step+1])
+            self.dW.assign(self.X[step + 1])
             if self.lambdas:
-                self.dW += self.X[step+1+self.nsteps]*(self.dt)**0.5
+                self.dW += self.X[step + 1 + self.nsteps] * (self.dt) ** 0.5
             self.dW_solver.solve()
 
             # Compute the streamfunction for the known value of q0
@@ -140,7 +137,7 @@ class Euler_SD(base_model):
             self.q_solver.solve()
 
             # Find new solution q^(n+1)
-            self.q0.assign(self.q0/3 + 2 * self.dq1/3)
+            self.q0.assign(self.q0 / 3 + 2 * self.dq1 / 3)
         X1[0].assign(self.q0)  # save sol at the nstep th time
 
     # control PV
@@ -174,10 +171,9 @@ class Euler_SD(base_model):
         count = 0
         for i in range(self.nsteps):
             count += 1
-            X[count].assign(c1*X[count] + c2*rg.normal(
-                self.W_F, 0., 1.0))
+            X[count].assign(c1 * X[count] + c2 * rg.normal(self.W_F, 0.0, 1.0))
             if g:
-                X[count] += gscale*g[count]
+                X[count] += gscale * g[count]
 
     def lambda_functional(self):
         nsteps = self.nsteps
@@ -187,8 +183,9 @@ class Euler_SD(base_model):
             dW_step = self.X[1 + step]
             dx = fd.dx
             dlfunc = fd.assemble(
-                (1/self.alpha_w)*lambda_step**2*dt/2*dx
-                - (1/self.alpha_w)*lambda_step*dW_step*dt**0.5*dx)
+                (1 / self.alpha_w) * lambda_step**2 * dt / 2 * dx
+                - (1 / self.alpha_w) * lambda_step * dW_step * dt**0.5 * dx
+            )
             if step == 0:
                 lfunc = dlfunc
             else:

--- a/nudging/parallel_arrays.py
+++ b/nudging/parallel_arrays.py
@@ -4,17 +4,17 @@ from numpy import asarray
 
 
 def in_range(i, length, allow_negative=True, throws=False):
-    '''
+    """
     Is the index i within the range of length?
     :arg i: index to check
     :arg length: the number of elements in the range
     :arg allow_negative: is negative indexing allowed?
     :arg throws: if True, an IndexError is raised if the index is out of range
-    '''
+    """
     if allow_negative:
-        result = (-length <= i < length)
+        result = -length <= i < length
     else:
-        result = (0 <= i < length)
+        result = 0 <= i < length
     if throws and result is False:
         raise IndexError(f"Index {i} is outside the range {length}")
     return result
@@ -22,7 +22,7 @@ def in_range(i, length, allow_negative=True, throws=False):
 
 class DistributedDataLayout1D(object):
     def __init__(self, partition, comm=MPI.COMM_WORLD):
-        '''A representation of a 1D set of data distributed over several MPI
+        """A representation of a 1D set of data distributed over several MPI
         ranks.
 
         :arg partition: The number of data elements on each rank. Can
@@ -32,47 +32,48 @@ class DistributedDataLayout1D(object):
 
         :arg comm: MPI communicator the data is distributed over.
 
-        '''
+        """
         if isinstance(partition, int):
             partition = tuple(partition for _ in range(comm.size))
         else:
             if len(partition) != comm.size:
                 raise ValueError(
                     f"Partition size {len(partition)} not\
-                    equal to comm size {comm.size}")
+                    equal to comm size {comm.size}"
+                )
             partition = tuple(partition)
         self.partition = partition
         self.comm = comm
         self.rank = comm.rank
         self.local_size = partition[self.rank]
         self.global_size = sum(partition)
-        self.offset = sum(partition[:self.rank])
+        self.offset = sum(partition[: self.rank])
 
-    def transform_index(self, i, itype='l', rtype='l'):
-        '''Shift index between local and global addressing, and transform
-        negative indices to their positive equivalent.
+    def transform_index(self, i, itype="l", rtype="l"):
+        """Shift index between local and global addressing, and transform
+                negative indices to their positive equivalent.
 
-        For example if there are 3 ranks each owning two elements then:
-            global indices 0,1 are local indices 0,1 on rank 0.
-            global indices 2,3 are local indices 0,1 on rank 1.
-            global indices 4,5 are local indices 0,1 on rank 2.
-        Negative indices are shifted to their positive equivalent:
-            local index -1 becomes local index 1.
-            global index -2 becomes local index 0 on rank 2.
+                For example if there are 3 ranks each owning two elements then:
+                    global indices 0,1 are local indices 0,1 on rank 0.
+                    global indices 2,3 are local indices 0,1 on rank 1.
+                    global indices 4,5 are local indices 0,1 on rank 2.
+                Negative indices are shifted to their positive equivalent:
+                    local index -1 becomes local index 1.
+                    global index -2 becomes local index 0 on rank 2.
 
-        Throws IndexError if original or shifted index is out of bounds.
-        :arg i: index to shift.
-        :arg itype: type of index i. 'l' for local, 'g' for global.
-        :arg rtype: type of returned shifted index. 'l' for local, 'g' for
-global.
-        '''
-        if itype not in ['l', 'g']:
+                Throws IndexError if original or shifted index is out of bounds.
+                :arg i: index to shift.
+                :arg itype: type of index i. 'l' for local, 'g' for global.
+                :arg rtype: type of returned shifted index. 'l' for local, 'g' for
+        global.
+        """
+        if itype not in ["l", "g"]:
             raise ValueError(f"itype {itype} must be either 'l' or 'g'")
-        if rtype not in ['l', 'g']:
+        if rtype not in ["l", "g"]:
             raise ValueError(f"rtype {rtype} must be either 'l' or 'g'")
 
         # validate
-        sizes = {'l': self.local_size, 'g': self.global_size}
+        sizes = {"l": self.local_size, "g": self.global_size}
         in_range(i, sizes[itype], throws=True)
 
         # deal with -ve index
@@ -82,22 +83,22 @@ global.
         if itype == rtype:
             return i
         else:
-            if itype == 'l':  # rtype == 'g'
+            if itype == "l":  # rtype == 'g'
                 i += self.offset
-            elif itype == 'g':  # rtype == 'l'
+            elif itype == "g":  # rtype == 'l'
                 i -= self.offset
             in_range(i, sizes[rtype], allow_negative=False, throws=True)
             return i
 
     def is_local(self, i, throws=False):
-        '''
+        """
         Is the globally addressed index i owned by this time rank?
         :arg i: globally addressed index.
         :arg throws: if True, raises IndexError if i is outside
         the global address range
-        '''
+        """
         try:
-            self.transform_index(i, itype='g', rtype='l')
+            self.transform_index(i, itype="g", rtype="l")
             return True
         except IndexError:
             if throws:
@@ -108,7 +109,7 @@ global.
 
 class SharedArray(object):
     def __init__(self, partition, dtype=None, comm=MPI.COMM_WORLD):
-        '''
+        """
         1D array shared over an MPI comm.
         Each rank has a copy of the entire array of size sum(partition)
         but can only  modify the partition[comm.rank] section of the array.
@@ -119,7 +120,7 @@ class SharedArray(object):
         number of elements.
         :arg dtype: datatype, defaults to numpy default dtype.
         :arg comm: MPI communicator that the array is distributed over.
-        '''
+        """
         self.comm = comm
         self.rank = comm.rank
         self.layout = DistributedDataLayout1D(partition, comm=comm)
@@ -134,9 +135,10 @@ class SharedArray(object):
         self.dlocal = self._LocalAccessor(self.layout, self._data)
 
     class _GlobalAccessor(object):
-        '''
+        """
         Manage access by global addressing
-        '''
+        """
+
         def __init__(self, layout, data):
             self.layout = layout
             self._data = data
@@ -149,19 +151,20 @@ class SharedArray(object):
             self._data[i] = val
 
     class _LocalAccessor(object):
-        '''
+        """
         Manage access by local addressing
-        '''
+        """
+
         def __init__(self, layout, data):
             self.layout = layout
             self._data = data
 
         def __getitem__(self, i):
-            i = self.layout.transform_index(i, itype='l', rtype='g')
+            i = self.layout.transform_index(i, itype="l", rtype="g")
             return self._data[i]
 
         def __setitem__(self, i, val):
-            i = self.layout.transform_index(i, itype='l', rtype='g')
+            i = self.layout.transform_index(i, itype="l", rtype="g")
             self._data[i] = val
 
     def synchronise(self, root=None):
@@ -204,7 +207,7 @@ class SharedArray(object):
 
 class OwnedArray(object):
     def __init__(self, size, owner=0, comm=MPI.COMM_WORLD, dtype=None):
-        '''Array owned by one rank but viewed over an MPI comm.  The array
+        """Array owned by one rank but viewed over an MPI comm.  The array
         can only be modified by the root rank, but every rank has a
         copy of the entire array.  Modifying the array from any rank
         other than root invalidates the data.
@@ -214,10 +217,12 @@ class OwnedArray(object):
         :arg comm: MPI communicator the array is synchronised over.
         :arg owner: owning rank.
 
-        '''
+        """
         if not isinstance(size, int):
-            raise ValueError("Array size must be of type int.\
-            OwnedArray only supports 1D arrays")
+            raise ValueError(
+                "Array size must be of type int.\
+            OwnedArray only supports 1D arrays"
+            )
 
         self.size = size
         self.comm = comm
@@ -227,42 +232,46 @@ class OwnedArray(object):
         self._data = zero_array(size, dtype=dtype)
 
     def is_owner(self):
-        '''
+        """
         Is the array owned by the current rank?
-        '''
+        """
         return self.rank == self.owner
 
     def __getitem__(self, i):
-        '''
+        """
         Get the value of the element at index i
-        '''
+        """
         return self._data[i]
 
     def __setitem__(self, i, val):
-        '''Set the value of the element at index i to val. Throws if the
+        """Set the value of the element at index i to val. Throws if the
         current rank does not own the array.
 
-        '''
+        """
         if not self.is_owner():
-            raise IndexError(f"Rank {self.rank} is not the\
-            owning rank {self.owner}")
+            raise IndexError(
+                f"Rank {self.rank} is not the\
+            owning rank {self.owner}"
+            )
         self._data[i] = val
 
     def synchronise(self):
-        '''Synchronise the array over the comm. Until this method is called,
+        """Synchronise the array over the comm. Until this method is called,
         array elements on any rank but root are not guaranteed to be
         valid
 
-        '''
+        """
         self.comm.Bcast(self._data, root=self.owner)
 
     def resize(self, size):
-        '''
+        """
         Resize array to size
-        '''
+        """
         if not isinstance(size, int):
-            raise ValueError("Array size must be of type int.\
-            OwnedArray only supports 1D arrays")
+            raise ValueError(
+                "Array size must be of type int.\
+            OwnedArray only supports 1D arrays"
+            )
         self._data.resize(size, refcheck=False)
         self.size = size
 

--- a/nudging/pfilter.py
+++ b/nudging/pfilter.py
@@ -17,24 +17,32 @@ from .resampling import residual_resampling
 from .diagnostics import compute_diagnostics, Stage, archive_diagnostics
 import numpy as np
 from .parallel_arrays import DistributedDataLayout1D, SharedArray, OwnedArray
-from firedrake.adjoint import pause_annotation, continue_annotation, \
-    get_working_tape, taylor_test
-from .global_optimisation import ensemble_tao_solver, \
-        ParameterisedEnsembleReducedFunctional
+from firedrake.adjoint import (
+    pause_annotation,
+    continue_annotation,
+    get_working_tape,
+    taylor_test,
+)
+from .global_optimisation import (
+    ensemble_tao_solver,
+    ParameterisedEnsembleReducedFunctional,
+)
 
 Print = PETSc.Sys.Print
+
+
 def logsumexp(x):
     c = x.max()
     return c + np.log(np.sum(np.exp(x - c)))
 
 
 def logsumexp_adjfloat(x, factor=fadj.AdjFloat(1.0)):
-    c = factor*x[0]
+    c = factor * x[0]
     for i in range(1, len(x)):
-        c = pmax(c, factor*x[i])
-    sumexp = pexp(factor*x[0] - c)
+        c = pmax(c, factor * x[i])
+    sumexp = pexp(factor * x[0] - c)
     for i in range(1, len(x)):
-        sumexp = sumexp + pexp(factor*x[i] - c)
+        sumexp = sumexp + pexp(factor * x[i] - c)
     c = c + plog(sumexp)
     return c
 
@@ -46,8 +54,7 @@ class base_filter(object, metaclass=ABCMeta):
     def __init__(self):
         pass
 
-    def setup(self, nensemble, model, resampler_seed=34343,
-              residual=False):
+    def setup(self, nensemble, model, resampler_seed=34343, residual=False):
         """
         Construct the ensemble
 
@@ -57,15 +64,14 @@ class base_filter(object, metaclass=ABCMeta):
         self.model = model
         self.nensemble = nensemble
         n_ensemble_partitions = len(nensemble)
-        self.nspace = int(MPI.COMM_WORLD.size/n_ensemble_partitions)
-        assert self.nspace*n_ensemble_partitions == MPI.COMM_WORLD.size
+        self.nspace = int(MPI.COMM_WORLD.size / n_ensemble_partitions)
+        assert self.nspace * n_ensemble_partitions == MPI.COMM_WORLD.size
 
         self.subcommunicators = fd.Ensemble(MPI.COMM_WORLD, self.nspace)
         # model needs to build the mesh in setup
         self.model.setup(self.subcommunicators.comm)
         if isinstance(nensemble, int):
-            nensemble = tuple(nensemble for _ in
-                              range(self.subcommunicators.comm.size))
+            nensemble = tuple(nensemble for _ in range(self.subcommunicators.comm.size))
 
         # setting up ensemble
         self.ensemble_rank = self.subcommunicators.ensemble_comm.rank
@@ -84,24 +90,21 @@ class base_filter(object, metaclass=ABCMeta):
 
         # Shared array for the potentials
         ecomm = self.subcommunicators.ensemble_comm
-        self.potential_arr = SharedArray(partition=self.nensemble, dtype=float,
-                                         comm=ecomm)
+        self.potential_arr = SharedArray(
+            partition=self.nensemble, dtype=float, comm=ecomm
+        )
 
         # Owned array for the resampling protocol
-        self.s_arr = OwnedArray(size=self.nglobal, dtype=int,
-                                comm=ecomm,
-                                owner=0)
+        self.s_arr = OwnedArray(size=self.nglobal, dtype=int, comm=ecomm, owner=0)
         # data layout for coordinating resampling communication
-        self.layout = DistributedDataLayout1D(self.nensemble,
-                                              comm=ecomm)
+        self.layout = DistributedDataLayout1D(self.nensemble, comm=ecomm)
 
         # offset_list
         self.offset_list = []
         for i_rank in range(len(self.nensemble)):
             self.offset_list.append(sum(self.nensemble[:i_rank]))
         # a resampling method
-        self.resampler = residual_resampling(seed=resampler_seed,
-                                             residual=residual)
+        self.resampler = residual_resampling(seed=resampler_seed, residual=residual)
 
     def index2rank(self, index):
         for rank in range(len(self.offset_list)):
@@ -119,15 +122,14 @@ class base_filter(object, metaclass=ABCMeta):
             if self.ensemble_rank == 0:
                 potentials = self.potential_arr.data()
                 # renormalise
-                weights = np.exp(-dtheta*potentials
-                                 - logsumexp(-dtheta*potentials))
-                assert np.abs(np.sum(weights)-1) < 1.0e-8
-                self.ess = 1/np.sum(weights**2)
+                weights = np.exp(-dtheta * potentials - logsumexp(-dtheta * potentials))
+                assert np.abs(np.sum(weights) - 1) < 1.0e-8
+                self.ess = 1 / np.sum(weights**2)
                 if self.verbose:
-                    PETSc.Sys.Print("ESS "
-                                    + str(100*self.ess/np.sum(self.nensemble))
-                                    + "%")
-            # compute resampling protocol on rank 0
+                    PETSc.Sys.Print(
+                        "ESS " + str(100 * self.ess / np.sum(self.nensemble)) + "%"
+                    )
+                # compute resampling protocol on rank 0
                 s = self.resampler.resample(weights, self.model)
                 for i in range(self.nglobal):
                     self.s_arr[i] = s[i]
@@ -140,8 +142,7 @@ class base_filter(object, metaclass=ABCMeta):
         mpi_requests = []
 
         for ilocal in range(self.nensemble[self.ensemble_rank]):
-            iglobal = self.layout.transform_index(ilocal, itype='l',
-                                                  rtype='g')
+            iglobal = self.layout.transform_index(ilocal, itype="l", rtype="g")
             # add to send list
             targets = []
             for j in range(self.s_arr.size):
@@ -154,13 +155,13 @@ class base_filter(object, metaclass=ABCMeta):
                         request_send = self.subcommunicators.isend(
                             self.ensemble[ilocal][k],
                             dest=self.index2rank(target),
-                            tag=1000*target+k)
+                            tag=1000 * target + k,
+                        )
                         mpi_requests.extend(request_send)
                 else:
                     request_send = self.subcommunicators.isend(
-                        self.ensemble[ilocal],
-                        dest=self.index2rank(target),
-                        tag=target)
+                        self.ensemble[ilocal], dest=self.index2rank(target), tag=target
+                    )
                     mpi_requests.extend(request_send)
 
             source_rank = self.index2rank(s_copy[iglobal])
@@ -169,13 +170,13 @@ class base_filter(object, metaclass=ABCMeta):
                     request_recv = self.subcommunicators.irecv(
                         self.new_ensemble[ilocal][k],
                         source=source_rank,
-                        tag=1000*iglobal+k)
+                        tag=1000 * iglobal + k,
+                    )
                     mpi_requests.extend(request_recv)
             else:
                 request_recv = self.subcommunicators.irecv(
-                    self.new_ensemble[ilocal],
-                    source=source_rank,
-                    tag=iglobal)
+                    self.new_ensemble[ilocal], source=source_rank, tag=iglobal
+                )
                 mpi_requests.extend(request_recv)
 
         MPI.Request.Waitall(mpi_requests)
@@ -204,7 +205,7 @@ class sim_filter(base_filter):
     def assimilation_step(self, s):
         for i in range(self.nensemble[self.ensemble_rank]):
             # set the particle value to the global index
-            self.ensemble[i][0].assign(self.offset_list[self.ensemble_rank]+i)
+            self.ensemble[i][0].assign(self.offset_list[self.ensemble_rank] + i)
         self.parallel_resample(s=s)
 
 
@@ -225,17 +226,26 @@ class bootstrap_filter(base_filter):
             Y = self.model.obs()
             self.potential_arr.dlocal[i] = fd.assemble(log_likelihood(y, Y))
         self.parallel_resample()
-        compute_diagnostics(diagnostics,
-                            self.ensemble,
-                            stage=Stage.AFTER_ASSIMILATION_STEP,
-                            descriptor=None)
+        compute_diagnostics(
+            diagnostics,
+            self.ensemble,
+            stage=Stage.AFTER_ASSIMILATION_STEP,
+            descriptor=None,
+        )
         archive_diagnostics(diagnostics)
 
 
 class jittertemp_filter(base_filter):
-    def __init__(self, n_jitt, delta,
-                 verbose=0, MALA=False, nudging=False,
-                 visualise_tape=False, sigma=0.1):
+    def __init__(
+        self,
+        n_jitt,
+        delta,
+        verbose=0,
+        MALA=False,
+        nudging=False,
+        visualise_tape=False,
+        sigma=0.1,
+    ):
         self.delta = delta
         self.verbose = verbose
         self.MALA = MALA
@@ -246,43 +256,43 @@ class jittertemp_filter(base_filter):
         self.sigma = sigma  # nudging parameter
 
         if MALA:
-            PETSc.Sys.Print("Warning, we are not currently "
-                            + "computing the Metropolis correction for MALA."
-                            + " Choose a small delta.")
+            PETSc.Sys.Print(
+                "Warning, we are not currently "
+                + "computing the Metropolis correction for MALA."
+                + " Choose a small delta."
+            )
 
     def setup(self, nensemble, model, resampler_seed=34343, residual=False):
         super(jittertemp_filter, self).setup(
-            nensemble, model, resampler_seed=resampler_seed,
-            residual=residual)
+            nensemble, model, resampler_seed=resampler_seed, residual=residual
+        )
         # Owned array for sending dtheta
         ecomm = self.subcommunicators.ensemble_comm
-        self.dtheta_arr = OwnedArray(size=self.nglobal, dtype=float,
-                                     comm=ecomm, owner=0)
+        self.dtheta_arr = OwnedArray(
+            size=self.nglobal, dtype=float, comm=ecomm, owner=0
+        )
         # Shared array for minimum potential values
-        self.phi_min = SharedArray(partition=self.nensemble, dtype=float,
-                                         comm=ecomm) # Shared array for maximum potential values
-        self.phi_max = SharedArray(partition=self.nensemble, dtype=float,
-                                         comm=ecomm)
-         # Shared array for optimize potential values
-        self.phi_opt = SharedArray(partition=self.nensemble, dtype=float,
-                                         comm=ecomm)
+        self.phi_min = SharedArray(
+            partition=self.nensemble, dtype=float, comm=ecomm
+        )  # Shared array for maximum potential values
+        self.phi_max = SharedArray(partition=self.nensemble, dtype=float, comm=ecomm)
+        # Shared array for optimize potential values
+        self.phi_opt = SharedArray(partition=self.nensemble, dtype=float, comm=ecomm)
         # Owned array for sending chosen potential values phi star
-        self.phi_star = OwnedArray(size=self.nglobal, dtype=float,
-                                     comm=ecomm, owner=0)
+        self.phi_star = OwnedArray(size=self.nglobal, dtype=float, comm=ecomm, owner=0)
 
     def adaptive_dtheta(self, dtheta, theta, ess_tol):
         self.potential_arr.synchronise(root=0)
         if self.ensemble_rank == 0:
             potentials = self.potential_arr.data()
-            ess = 0.
-            while ess < ess_tol*sum(self.nensemble):
+            ess = 0.0
+            while ess < ess_tol * sum(self.nensemble):
                 # renormalise
-                weights = np.exp(-dtheta*potentials
-                                 - logsumexp(-dtheta*potentials))
+                weights = np.exp(-dtheta * potentials - logsumexp(-dtheta * potentials))
                 weights /= np.sum(weights)
-                ess = 1/np.sum(weights**2)
-                if ess < ess_tol*sum(self.nensemble):
-                    dtheta = 0.5*dtheta
+                ess = 1 / np.sum(weights**2)
+                if ess < ess_tol * sum(self.nensemble):
+                    dtheta = 0.5 * dtheta
 
             # abuse owned array to broadcast dtheta
             for i in range(self.nglobal):
@@ -315,34 +325,29 @@ class jittertemp_filter(base_filter):
         for i in range(N):  # build functionals for each particle
             for step in range(nsteps):
                 #  adding Lambda to the controls for this step
-                self.Control_inputs[step].append(
-                    self.ensemble[i][nsteps+1+step])
-                Controls[step].append(fadj.Control(
-                    self.ensemble[i][nsteps+1+step]))
+                self.Control_inputs[step].append(self.ensemble[i][nsteps + 1 + step])
+                Controls[step].append(fadj.Control(self.ensemble[i][nsteps + 1 + step]))
                 #  adding model state to the parameters
-                self.Parameter_inputs[step].append(
-                    self.ensemble[i][0])
-                Parameters[step].append(
-                    fadj.Control(self.ensemble[i][0]))
+                self.Parameter_inputs[step].append(self.ensemble[i][0])
+                Parameters[step].append(fadj.Control(self.ensemble[i][0]))
                 #  adding noise values to the parameters
                 for step2 in range(nsteps):
-                    self.Parameter_inputs[step].append(
-                        self.ensemble[i][1+step2])
-                    Parameters[step].append(
-                        fadj.Control(self.ensemble[i][1+step2]))
+                    self.Parameter_inputs[step].append(self.ensemble[i][1 + step2])
+                    Parameters[step].append(fadj.Control(self.ensemble[i][1 + step2]))
 
                     #  adding Lambda for other steps as parameters
                     for step2 in range(nsteps):
                         if step2 == step:
                             continue
                         self.Parameter_inputs[step].append(
-                            self.ensemble[i][nsteps+1+step2])
-                        Parameters[step].append(fadj.Control(
-                            self.ensemble[i][nsteps+1+step2]))
+                            self.ensemble[i][nsteps + 1 + step2]
+                        )
+                        Parameters[step].append(
+                            fadj.Control(self.ensemble[i][nsteps + 1 + step2])
+                        )
 
             # tape model for local particle i
-            self.model.run(self.ensemble[i],
-                           self.new_ensemble[i])
+            self.model.run(self.ensemble[i], self.new_ensemble[i])
             Y = self.model.obs()
             nudge_J = fd.assemble(log_likelihood(y, Y))
             nudge_J += self.model.lambda_functional()
@@ -372,20 +377,21 @@ class jittertemp_filter(base_filter):
         # we only update lambdas[step] on timestep step
         for step in range(nsteps):
             # build the RF that maps from the Js to the BigJ
-            BigJ = -2*logsumexp_adjfloat(BigJ_floats,
-                                         factor=-1.0)
+            BigJ = -2 * logsumexp_adjfloat(BigJ_floats, factor=-1.0)
             BigJ += logsumexp_adjfloat(BigJ_floats, factor=-2.0)
             for Jfloat in BigJ_floats:
-                BigJ += Jfloat*self.sigma
+                BigJ += Jfloat * self.sigma
             BigJ_Controls = [fadj.Control(fl) for fl in BigJ_floats]
             BigJhat = fadj.ReducedFunctional(BigJ, BigJ_Controls)
 
-            assert len(Parameters[step]) == \
-                len(self.Parameter_inputs[step])
+            assert len(Parameters[step]) == len(self.Parameter_inputs[step])
             rf = ParameterisedEnsembleReducedFunctional(
-                Js, Controls[step], Parameters[step],
+                Js,
+                Controls[step],
+                Parameters[step],
                 self.subcommunicators,
-                gather_functional=BigJhat)
+                gather_functional=BigJhat,
+            )
             for input0 in self.Control_inputs[step]:
                 input0.assign(1.0)
 
@@ -395,16 +401,22 @@ class jittertemp_filter(base_filter):
 
                 rf(self.Control_inputs[step])
                 Drf = rf.derivative()
-                dJdm = 0.
+                dJdm = 0.0
                 pert = self.Control_inputs[step]
                 for i, D in enumerate(Drf):
-                    dJdm += fd.assemble(fd.inner(D, pert[i])*fd.dx)
-                dJdm = self.subcommunicators.ensemble_comm.allreduce(
-                    dJdm, op=MPI.SUM)
-                assert taylor_test(
-                    rf, self.Control_inputs[step],
-                    self.Control_inputs[step], dJdm=dJdm) > 1.9
+                    dJdm += fd.assemble(fd.inner(D, pert[i]) * fd.dx)
+                dJdm = self.subcommunicators.ensemble_comm.allreduce(dJdm, op=MPI.SUM)
+                assert (
+                    taylor_test(
+                        rf,
+                        self.Control_inputs[step],
+                        self.Control_inputs[step],
+                        dJdm=dJdm,
+                    )
+                    > 1.9
+                )
                 from sys import exit
+
                 exit()
 
             self.rfs.append(rf)
@@ -412,16 +424,22 @@ class jittertemp_filter(base_filter):
                 params = self.tao_params
             elif isinstance(self.tao_params, list):
                 params = self.tao_params[step]
-            
-            solver = ensemble_tao_solver(rf, self.subcommunicators.comm,
-                                         solver_parameters=params)
+
+            solver = ensemble_tao_solver(
+                rf, self.subcommunicators.comm, solver_parameters=params
+            )
             self.Jhat_solvers.append(solver)
 
-    def assimilation_step(self, y, log_likelihood,
-                          diagnostics=[],
-                          ess_tol=0.8, tao_params=None,
-                          taylor_test=False):
-        #self.y = y
+    def assimilation_step(
+        self,
+        y,
+        log_likelihood,
+        diagnostics=[],
+        ess_tol=0.8,
+        tao_params=None,
+        taylor_test=False,
+    ):
+        # self.y = y
         if not tao_params:
             self.tao_params = {
                 "tao_type": "lmvm",
@@ -455,8 +473,7 @@ class jittertemp_filter(base_filter):
                 scale_controls.append(fadj.Control(s))
             if self.verbose > 0:
                 PETSc.Sys.Print("taping forward model for Nudging")
-            self.model.run(self.ensemble[0],
-                            self.new_ensemble[0], s=self.scale)
+            self.model.run(self.ensemble[0], self.new_ensemble[0], s=self.scale)
             # set the controls
             if isinstance(y, fd.Function):
                 m = self.model.controls() + [fadj.Control(y)] + scale_controls
@@ -472,7 +489,7 @@ class jittertemp_filter(base_filter):
                 # functional for nudging
                 self.Jhat = []
                 self.Jhat_solvers = []
-                for step in range(nsteps+1, nsteps*2+1):
+                for step in range(nsteps + 1, nsteps * 2 + 1):
                     # 0 component is state
                     # 1 .. step is noise
                     # step + 1 .. 2*step is lambdas
@@ -480,9 +497,7 @@ class jittertemp_filter(base_filter):
                     # we only update lambdas[step] on timestep step
                     cpts = [step]
 
-                    fnl = fadj.ReducedFunctional(nudge_J,
-                                                 m,
-                                                 derivative_components=cpts)
+                    fnl = fadj.ReducedFunctional(nudge_J, m, derivative_components=cpts)
 
                     self.Jhat.append(fnl)
             if self.visualise_tape:
@@ -498,8 +513,9 @@ class jittertemp_filter(base_filter):
                 for fnl in self.Jhat:
                     # testing the derivative
                     problem = MinimizationProblem(fnl)
-                    solver = TAOSolver(problem, self.tao_params,
-                                       comm=self.subcommunicators.comm)
+                    solver = TAOSolver(
+                        problem, self.tao_params, comm=self.subcommunicators.comm
+                    )
                     self.Jhat_solvers.append(solver)
 
         if self.nudging:
@@ -512,8 +528,8 @@ class jittertemp_filter(base_filter):
                 self.proposal_ensemble[i][0].assign(self.ensemble[i][0])
                 # zero the noise and lambdas in preparation for nudging
                 for step in range(nsteps):
-                    self.ensemble[i][step+1].assign(0.)  # the noise
-                    self.ensemble[i][nsteps+step+1].assign(0.)  # the nudging
+                    self.ensemble[i][step + 1].assign(0.0)  # the noise
+                    self.ensemble[i][nsteps + step + 1].assign(0.0)  # the nudging
 
             # Stage 1: nudging one step at a time
             for step in range(nsteps):
@@ -523,80 +539,88 @@ class jittertemp_filter(base_filter):
                     # get the randomised noise for this step
                     self.model.randomize(self.new_ensemble[i])  # not efficient!
                     # just copy in the current component
-                    self.ensemble[i][1+step].assign(self.new_ensemble[i][1+step])
+                    self.ensemble[i][1 + step].assign(self.new_ensemble[i][1 + step])
                     # update with current noise and lambda values
                     # (prepare the scale values first)
                     for j in range(nsteps):
                         self.scale[j].assign(1.0)
-                    self.Jhat[step](self.ensemble[i]+[y]+self.scale)
+                    self.Jhat[step](self.ensemble[i] + [y] + self.scale)
 
                     # get the minimum over current lambda
                     if self.verbose > 1:
-                        PETSc.Sys.Print("Solving for Lambda step ", step,
-                                        "local ensemble member ", i)
+                        PETSc.Sys.Print(
+                            "Solving for Lambda step ",
+                            step,
+                            "local ensemble member ",
+                            i,
+                        )
                     Xopt = fadj.minimize(self.Jhat[step])
                     # place the optimal value of lambda into ensemble
-                    self.ensemble[i][nsteps+1+step].assign(Xopt[nsteps+1+step])
+                    self.ensemble[i][nsteps + 1 + step].assign(Xopt[nsteps + 1 + step])
                     # store the optimal value
-                    phi_min_i = self.Jhat[step](self.ensemble[i]+[y]+self.scale)
+                    phi_min_i = self.Jhat[step](self.ensemble[i] + [y] + self.scale)
                     phi_min_loc.append(phi_min_i)
                     self.phi_min.dlocal[i] = phi_min_i
                     self.scale[step].assign(-1.0)
-                    phi_max_i = self.Jhat[step](self.ensemble[i]+[y]+self.scale)
+                    phi_max_i = self.Jhat[step](self.ensemble[i] + [y] + self.scale)
                     self.phi_max.dlocal[i] = phi_max_i
                     phi_max_loc.append(phi_max_i)
-                    self.scale[step].assign(1.0) # reset the scale values
+                    self.scale[step].assign(1.0)  # reset the scale values
                 self.phi_min.synchronise()
                 self.phi_max.synchronise()
                 self.ess_count = 0
 
                 # Stage 2: find the phi values that minimise phis subject to ESS > tol
-                #with PETSc.Log.Event("Stage 2: Global Optimization"):
+                # with PETSc.Log.Event("Stage 2: Global Optimization"):
                 if self.ensemble_rank == 0:
                     phi_max = self.phi_max.data()
                     phi_min = self.phi_min.data()
-                    #Print('phi_val', np.stack((phi_min, phi_max, phi_max - phi_min)).T)
-                    
+                    # Print('phi_val', np.stack((phi_min, phi_max, phi_max - phi_min)).T)
+
                     # Objective: minimize negative ESS
                     def maximizeESS(phi):
                         weights = np.exp(-phi - logsumexp(-phi))
                         weights /= np.sum(weights)
-                        ess = 1/np.sum(weights**2)
-                        return -ess + np.sum(phi)/100 # To maximize ESS
+                        ess = 1 / np.sum(weights**2)
+                        return -ess + np.sum(phi) / 100  # To maximize ESS
 
                     # Define bounds
-                    assert np.all(phi_min <= phi_max), np.stack((phi_min, phi_max, phi_min - phi_max)).T
+                    assert np.all(phi_min <= phi_max), np.stack(
+                        (phi_min, phi_max, phi_min - phi_max)
+                    ).T
                     lower_bounds = phi_min
                     upper_bounds = phi_max
 
-                    bounds = Bounds(phi_min, 2*phi_max)
+                    bounds = Bounds(phi_min, 2 * phi_max)
+
                     # Initial guess: midpoint
                     def phi_init(delta):
-                        return delta*phi_min + (1-delta)*phi_max
-                    #x0 = phi_min
+                        return delta * phi_min + (1 - delta) * phi_max
+
+                    # x0 = phi_min
                     # Run the optimization
                     if self.verbose > 1:
                         Print("Minimising global functional")
 
                     result = minimize(
-                                maximizeESS,
-                                x0 = phi_init(0.5),
-                                method='L-BFGS-B',
-                                bounds=bounds,
-                                #hess=lambda x: csc_matrix((len(x), len(x))),  # zero Hessian
-                                #options={'verbose': 1, 'maxiter': 10000}
-                            )
+                        maximizeESS,
+                        x0=phi_init(0.5),
+                        method="L-BFGS-B",
+                        bounds=bounds,
+                        # hess=lambda x: csc_matrix((len(x), len(x))),  # zero Hessian
+                        # options={'verbose': 1, 'maxiter': 10000}
+                    )
                     # Use optimized phi
                     phi_opt = result.x
-                    a = np.stack((np.arange(len(phi_min)), phi_min,phi_opt, phi_max)).T
+                    a = np.stack((np.arange(len(phi_min)), phi_min, phi_opt, phi_max)).T
                     if self.verbose > 2:
                         Print("Optimized phi")
-                        #Print(a)
+                        # Print(a)
                     if self.verbose > 1:
                         weights = np.exp(-phi_opt - logsumexp(-phi_opt))
                         weights /= np.sum(weights)
-                        ess = 1/np.sum(weights**2)
-                        self.ess_count  = ess
+                        ess = 1 / np.sum(weights**2)
+                        self.ess_count = ess
                         Print("Maximum ESS achieved:", ess)
 
                     for i in range(self.nglobal):
@@ -604,57 +628,65 @@ class jittertemp_filter(base_filter):
                 self.phi_star.synchronise()
 
                 # Stage 3: find the scaling of lambda to achieve phi_star
-                #with PETSc.Log.Event("Stage 3: Lambda Rescaling"):
+                # with PETSc.Log.Event("Stage 3: Lambda Rescaling"):
                 if self.verbose > 1:
                     Print("Rescaling lambda to optimal value")
                 for i in range(self.nensemble[self.ensemble_rank]):
-                    ig = self.layout.transform_index(i, itype='l', rtype='g')
+                    ig = self.layout.transform_index(i, itype="l", rtype="g")
                     phi_star = self.phi_star.data()[ig]
 
                     if abs(phi_star - phi_min_loc[i]) < 1.0e-8:
                         # do nothing because we are at the minimum
                         continue
                     elif phi_star < phi_min_loc[i]:
-                        raise ValueError('bad phi_star value')
+                        raise ValueError("bad phi_star value")
                     else:
+
                         def func(s):
                             self.scale[step].assign(s)
-                            val = self.Jhat[step](self.ensemble[i]+[y] + self.scale)
+                            val = self.Jhat[step](self.ensemble[i] + [y] + self.scale)
                             val = val - phi_star
                             self.scale[step].assign(1.0)
                             return val
 
-                        b = 0.
+                        b = 0.0
                         while func(b) < 0:
                             b -= 1
                         # get the scale value
-                        sol = root_scalar(func, bracket=[b, b+1.],   method="brentq").root
+                        sol = root_scalar(
+                            func, bracket=[b, b + 1.0], method="brentq"
+                        ).root
 
-                        lambda_step = self.ensemble[i][nsteps+step+1]
-                        lambda_step.assign(sol*lambda_step)
+                        lambda_step = self.ensemble[i][nsteps + step + 1]
+                        lambda_step.assign(sol * lambda_step)
 
                         self.scale[step].assign(1.0)
-                        val = self.Jhat[step](self.ensemble[i]+[y] + self.scale)
+                        val = self.Jhat[step](self.ensemble[i] + [y] + self.scale)
 
-                        assert abs(val - phi_star < 1.0e-3) , f'val:{val}, phi star:{phi_star}, step:{step}, sol:{sol}'
-
+                        assert abs(
+                            val - phi_star < 1.0e-3
+                        ), f"val:{val}, phi star:{phi_star}, step:{step}, sol:{sol}"
 
             PETSc.garbage_cleanup(PETSc.COMM_SELF)
 
-            compute_diagnostics(diagnostics,
-                                self.ensemble,
-                                descriptor=None,
-                                stage=Stage.AFTER_NUDGING,
-                                run=lambda x, y: self.model.run(x, y, s=self.scale),
-                                new_ensemble=self.new_ensemble)
+            compute_diagnostics(
+                diagnostics,
+                self.ensemble,
+                descriptor=None,
+                stage=Stage.AFTER_NUDGING,
+                run=lambda x, y: self.model.run(x, y, s=self.scale),
+                new_ensemble=self.new_ensemble,
+            )
 
             self.model.lambdas = False
-            compute_diagnostics(diagnostics,
-                                self.ensemble,
-                                descriptor=None,
-                                stage=Stage.WITHOUT_LAMBDAS,
-                                run=self.model.run,
-                                new_ensemble=self.new_ensemble)
+            compute_diagnostics(
+                diagnostics,
+                self.ensemble,
+                descriptor=None,
+                stage=Stage.WITHOUT_LAMBDAS,
+                run=self.model.run,
+                new_ensemble=self.new_ensemble,
+            )
             self.model.lambdas = True
         else:
             for i in range(N):
@@ -663,7 +695,7 @@ class jittertemp_filter(base_filter):
 
         theta = 0.0
         self.temper_count = 0
-        while theta < 1.:  # Tempering loop
+        while theta < 1.0:  # Tempering loop
             dtheta = 1.0 - theta
 
             # Compute initial potentials
@@ -671,11 +703,9 @@ class jittertemp_filter(base_filter):
                 # put result of forward model into new_ensemble
                 self.model.run(self.ensemble[i], self.new_ensemble[i])
                 Y = self.model.obs()
-                self.potential_arr.dlocal[i] = \
-                    fd.assemble(log_likelihood(y, Y))
+                self.potential_arr.dlocal[i] = fd.assemble(log_likelihood(y, Y))
                 if self.nudging:
-                    self.potential_arr.dlocal[i] += \
-                        self.model.lambda_functional()
+                    self.potential_arr.dlocal[i] += self.model.lambda_functional()
 
             # adaptive dtheta choice
             dtheta = self.adaptive_dtheta(dtheta, theta, ess_tol)
@@ -686,12 +716,14 @@ class jittertemp_filter(base_filter):
 
             # resampling BEFORE jittering
             self.parallel_resample(dtheta)
-            compute_diagnostics(diagnostics,
-                                self.ensemble,
-                                descriptor=(dtheta),
-                                stage=Stage.AFTER_TEMPER_RESAMPLE,
-                                run=self.model.run,
-                                new_ensemble=self.new_ensemble)
+            compute_diagnostics(
+                diagnostics,
+                self.ensemble,
+                descriptor=(dtheta),
+                stage=Stage.AFTER_TEMPER_RESAMPLE,
+                run=self.model.run,
+                new_ensemble=self.new_ensemble,
+            )
             self.temper_count += 1
 
             for jitt_step in range(self.n_jitt):  # Jittering loop
@@ -701,11 +733,9 @@ class jittertemp_filter(base_filter):
                 for i in range(N):
                     if jitt_step == 0:
                         # Compute initial potentials
-                        self.model.run(self.ensemble[i],
-                                       self.new_ensemble[i])
+                        self.model.run(self.ensemble[i], self.new_ensemble[i])
                         Y = self.model.obs()
-                        potentials[i] = fd.assemble(
-                            log_likelihood(y, Y))
+                        potentials[i] = fd.assemble(log_likelihood(y, Y))
                         if self.nudging:
                             potentials[i] += self.model.lambda_functional()
                         potentials[i] *= theta
@@ -713,35 +743,34 @@ class jittertemp_filter(base_filter):
                     if self.MALA:
                         # run the model and get the functional value with
                         # ensemble[i]
-                        self.Jhat_dW(self.ensemble[i]+[y])
+                        self.Jhat_dW(self.ensemble[i] + [y])
                         # use the taped model to get the derivative
                         g = self.Jhat_dW.derivative()
                         # proposal
-                        self.model.copy(self.ensemble[i],
-                                        self.proposal_ensemble[i])
+                        self.model.copy(self.ensemble[i], self.proposal_ensemble[i])
                         delta = self.delta
-                        self.model.randomize(self.proposal_ensemble[i],
-                                             (
-                                                 (2-delta)/(2+delta)),
-                                             (
-                                                 (8*delta)**0.5/(2+delta)),
-                                             gscale=-2*delta/(2+delta), g=g)
+                        self.model.randomize(
+                            self.proposal_ensemble[i],
+                            ((2 - delta) / (2 + delta)),
+                            ((8 * delta) ** 0.5 / (2 + delta)),
+                            gscale=-2 * delta / (2 + delta),
+                            g=g,
+                        )
                     else:
                         # proposal PCN
-                        self.model.copy(self.ensemble[i],
-                                        self.proposal_ensemble[i])
+                        self.model.copy(self.ensemble[i], self.proposal_ensemble[i])
                         delta = self.delta
-                        self.model.randomize(self.proposal_ensemble[i],
-                                             (2-delta)/(2+delta),
-                                             (8*delta)**0.5/(2+delta))
+                        self.model.randomize(
+                            self.proposal_ensemble[i],
+                            (2 - delta) / (2 + delta),
+                            (8 * delta) ** 0.5 / (2 + delta),
+                        )
                     # put result of forward model into new_ensemble
-                    self.model.run(self.proposal_ensemble[i],
-                                   self.new_ensemble[i])
+                    self.model.run(self.proposal_ensemble[i], self.new_ensemble[i])
 
                     # particle potentials
                     Y = self.model.obs()
-                    new_potentials[i] = fd.assemble(
-                        log_likelihood(y, Y))
+                    new_potentials[i] = fd.assemble(log_likelihood(y, Y))
                     if self.nudging:
                         new_potentials[i] += self.model.lambda_functional()
                     new_potentials[i] *= theta
@@ -750,31 +779,32 @@ class jittertemp_filter(base_filter):
                     if self.MALA:
                         p_accept = 1
                     else:
-                        p_accept = min(1,
-                                       np.exp(potentials[i]
-                                              - new_potentials[i]))
+                        p_accept = min(1, np.exp(potentials[i] - new_potentials[i]))
                         # accept or reject tool
-                        u = self.model.rg.uniform(self.model.R, 0., 1.0)
+                        u = self.model.rg.uniform(self.model.R, 0.0, 1.0)
                         if u.dat.data[:] < p_accept:
                             potentials[i] = new_potentials[i]
-                            self.model.copy(self.proposal_ensemble[i],
-                                            self.ensemble[i])
-                compute_diagnostics(diagnostics,
-                                    self.ensemble,
-                                    descriptor=(dtheta, jitt_step),
-                                    stage=Stage.AFTER_ONE_JITTER_STEP,
-                                    run=self.model.run,
-                                    new_ensemble=self.new_ensemble)
+                            self.model.copy(self.proposal_ensemble[i], self.ensemble[i])
+                compute_diagnostics(
+                    diagnostics,
+                    self.ensemble,
+                    descriptor=(dtheta, jitt_step),
+                    stage=Stage.AFTER_ONE_JITTER_STEP,
+                    run=self.model.run,
+                    new_ensemble=self.new_ensemble,
+                )
 
-            compute_diagnostics(diagnostics,
-                                self.ensemble,
-                                descriptor=(dtheta),
-                                stage=Stage.AFTER_JITTERING,
-                                run=self.model.run,
-                                new_ensemble=self.new_ensemble)
+            compute_diagnostics(
+                diagnostics,
+                self.ensemble,
+                descriptor=(dtheta),
+                stage=Stage.AFTER_JITTERING,
+                run=self.model.run,
+                new_ensemble=self.new_ensemble,
+            )
 
         if self.verbose > 0:
-            PETSc.Sys.Print(str(self.temper_count)+" tempering steps")
+            PETSc.Sys.Print(str(self.temper_count) + " tempering steps")
             PETSc.Sys.Print("Advancing ensemble")
         for i in range(N):
             self.model.run(self.ensemble[i], self.ensemble[i])
@@ -782,8 +812,10 @@ class jittertemp_filter(base_filter):
             PETSc.Sys.Print("assimilation step complete")
         # trigger garbage cleanup
         PETSc.garbage_cleanup(PETSc.COMM_SELF)
-        compute_diagnostics(diagnostics,
-                            self.ensemble,
-                            descriptor=None,
-                            stage=Stage.AFTER_ASSIMILATION_STEP)
+        compute_diagnostics(
+            diagnostics,
+            self.ensemble,
+            descriptor=None,
+            stage=Stage.AFTER_ASSIMILATION_STEP,
+        )
         archive_diagnostics(diagnostics)

--- a/nudging/resampling.py
+++ b/nudging/resampling.py
@@ -28,17 +28,17 @@ class residual_resampling(object):
         N = weights.size
 
         if self.residual:
-            copies = np.array(np.floor(weights*N), dtype=int)
+            copies = np.array(np.floor(weights * N), dtype=int)
             L = N - np.sum(copies)
-            residual_weights = N*weights - copies
+            residual_weights = N * weights - copies
             residual_weights /= np.sum(residual_weights)
 
             for i in range(L):
-                u = self.rg.uniform(self.R, 0., 1.0)
+                u = self.rg.uniform(self.R, 0.0, 1.0)
                 u0 = u.dat.data[:]
                 cs = np.cumsum(residual_weights)
                 istar = -1
-                while cs[istar+1] < u0:
+                while cs[istar + 1] < u0:
                     istar += 1
                 copies[istar] += 1
 
@@ -51,10 +51,10 @@ class residual_resampling(object):
 
         else:  # systematic resampling
             cumsum_weight = np.cumsum(weights)
-            u = self.rg.uniform(self.R, 0., 1.0)
+            u = self.rg.uniform(self.R, 0.0, 1.0)
             u0 = u.dat.data[:]
 
-            ensembl_pos = (u0 + np.arange(N))/N
+            ensembl_pos = (u0 + np.arange(N)) / N
             s = np.zeros(N, dtype=int)
             i, j = 0, 0
             while i < N:

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,19 +1,25 @@
 from firedrake import dx
-from nudging import LSDEModel, bootstrap_filter, \
-    jittertemp_filter, base_diagnostic, Stage
+from nudging import (
+    LSDEModel,
+    bootstrap_filter,
+    jittertemp_filter,
+    base_diagnostic,
+    Stage,
+)
 import numpy as np
 import pytest
 
 
-def filter_linear_sde(testfilter, filterargs, mtol, vtol,
-                      p_per_rank, nranks, lambdas=False):
+def filter_linear_sde(
+    testfilter, filterargs, mtol, vtol, p_per_rank, nranks, lambdas=False
+):
     # model
     # multiply by A and add D
-    T = 1.
+    T = 1.0
     nsteps = 10
-    dt = T/nsteps
-    A = 1.
-    D = 1.
+    dt = T / nsteps
+    A = 1.0
+    D = 1.0
     model = LSDEModel(A=A, D=D, nsteps=nsteps, dt=dt, lambdas=lambdas)
 
     # solving
@@ -83,7 +89,7 @@ def filter_linear_sde(testfilter, filterargs, mtol, vtol,
     # then
     # x(1)|y ~ N((b^2y + S^2a)/(b^2+S^2), (b^2S^2)/(b^2 + S^2))
 
-    nensemble = [p_per_rank]*nranks
+    nensemble = [p_per_rank] * nranks
     filterargs["nensemble"] = nensemble
     filterargs["model"] = model
     testfilter.setup(**filterargs)
@@ -94,8 +100,8 @@ def filter_linear_sde(testfilter, filterargs, mtol, vtol,
     y.dat.data[:] = y0
 
     # prepare the initial ensemble
-    c = 0.
-    d = D**2/2/A
+    c = 0.0
+    d = D**2 / 2 / A
     for i in range(nensemble[testfilter.ensemble_rank]):
         dx0 = model.rg.normal(model.R, c, d)
         u = testfilter.ensemble[i][0]
@@ -105,7 +111,7 @@ def filter_linear_sde(testfilter, filterargs, mtol, vtol,
     S = 0.3
 
     def log_likelihood(y, Y):
-        ll = (y-Y)**2/S**2/2*dx
+        ll = (y - Y) ** 2 / S**2 / 2 * dx
         return ll
 
     # results in a diagnostic
@@ -114,12 +120,11 @@ def filter_linear_sde(testfilter, filterargs, mtol, vtol,
             model.u.assign(particle[0])
             return model.obs().dat.data[0]
 
-    samplesdiagnostic = samples(Stage.AFTER_ASSIMILATION_STEP,
-                                testfilter.subcommunicators,
-                                nensemble)
+    samplesdiagnostic = samples(
+        Stage.AFTER_ASSIMILATION_STEP, testfilter.subcommunicators, nensemble
+    )
     diagnostics = [samplesdiagnostic]
-    testfilter.assimilation_step(y, log_likelihood,
-                                 diagnostics=diagnostics)
+    testfilter.assimilation_step(y, log_likelihood, diagnostics=diagnostics)
 
     if testfilter.subcommunicators.global_comm.rank == 0:
         pvals, descriptors = samplesdiagnostic.get_archive()
@@ -127,10 +132,10 @@ def filter_linear_sde(testfilter, filterargs, mtol, vtol,
         bs_var = np.var(pvals)
 
         # analytical formula
-        sigsq = D**2/2/A*(1 - np.exp(-2*A*T))
-        Sigsq = sigsq + np.exp(-2*A*T)*d
-        tmean = (Sigsq*y0 + np.exp(-A*T)*S**2*c)/(Sigsq + S**2)
-        tvar = Sigsq*S**2/(Sigsq + S**2)
+        sigsq = D**2 / 2 / A * (1 - np.exp(-2 * A * T))
+        Sigsq = sigsq + np.exp(-2 * A * T) * d
+        tmean = (Sigsq * y0 + np.exp(-A * T) * S**2 * c) / (Sigsq + S**2)
+        tvar = Sigsq * S**2 / (Sigsq + S**2)
 
         assert np.abs(tmean - bs_mean) < mtol
         assert np.abs(tvar - bs_var) < vtol
@@ -138,26 +143,35 @@ def filter_linear_sde(testfilter, filterargs, mtol, vtol,
 
 @pytest.mark.parallel(nprocs=5)
 def test_bsfilter():
-    filter_linear_sde(bootstrap_filter(), {"residual": False},
-                      mtol=0.01, vtol=0.01,
-                      p_per_rank=200, nranks=5)
+    filter_linear_sde(
+        bootstrap_filter(),
+        {"residual": False},
+        mtol=0.01,
+        vtol=0.01,
+        p_per_rank=200,
+        nranks=5,
+    )
 
 
 @pytest.mark.parallel(nprocs=10)
 def test_jtfilter():
-    jtfilter = jittertemp_filter(n_jitt=5, delta=0.15,
-                                 verbose=True, MALA=False)
-    filter_linear_sde(jtfilter, {"residual": False},
-                      mtol=0.05, vtol=0.05,
-                      p_per_rank=10, nranks=10)
+    jtfilter = jittertemp_filter(n_jitt=5, delta=0.15, verbose=True, MALA=False)
+    filter_linear_sde(
+        jtfilter, {"residual": False}, mtol=0.05, vtol=0.05, p_per_rank=10, nranks=10
+    )
 
 
 @pytest.mark.parallel(nprocs=10)
 def test_nudgingfilter():
-    jtfilter = jittertemp_filter(n_jitt=5, delta=0.15,
-                                 verbose=False, MALA=False,
-                                 nudging=True)
-    filter_linear_sde(jtfilter, {"residual": False},
-                      mtol=0.05, vtol=0.05,
-                      p_per_rank=10, nranks=10,
-                      lambdas=True)
+    jtfilter = jittertemp_filter(
+        n_jitt=5, delta=0.15, verbose=False, MALA=False, nudging=True
+    )
+    filter_linear_sde(
+        jtfilter,
+        {"residual": False},
+        mtol=0.05,
+        vtol=0.05,
+        p_per_rank=10,
+        nranks=10,
+        lambdas=True,
+    )

--- a/tests/test_optimisation.py
+++ b/tests/test_optimisation.py
@@ -20,7 +20,7 @@ def test_ensemble_tao_solver():
     Controls = []
     xs = []
     for i in range(n_Js[rank]):
-        val = Js_offset[rank]+i+1
+        val = Js_offset[rank] + i + 1
         x = fd.Function(R, val=val)
         J = fd.assemble(x * x * fd.dx(domain=mesh))
         Js.append(J)
@@ -33,15 +33,15 @@ def test_ensemble_tao_solver():
         a = fadj.AdjFloat(1.0)
         as1.append(a)
         Jg_m.append(fadj.Control(a))
-    Ja = as1[0]**2
+    Ja = as1[0] ** 2
     for i in range(1, 5):
-        Ja += as1[i]**2
+        Ja += as1[i] ** 2
     Jg = fadj.ReducedFunctional(Ja, Jg_m)
     val = 1.0**2 + 2.0**2 + 3.0**2 + 4.0**2 + 5.0**2
-    assert Jg([1., 2., 3., 4., 5.]) == val
-    rf = fadj.EnsembleReducedFunctional(Js, Controls, ensemble,
-                                        scatter_control=False,
-                                        gather_functional=Jg)
+    assert Jg([1.0, 2.0, 3.0, 4.0, 5.0]) == val
+    rf = fadj.EnsembleReducedFunctional(
+        Js, Controls, ensemble, scatter_control=False, gather_functional=Jg
+    )
     fadj.stop_annotating()
 
     solver_parameters = {
@@ -49,8 +49,7 @@ def test_ensemble_tao_solver():
         "tao_cg_type": "pr",
     }
 
-    solver = ensemble_tao_solver(rf, ensemble,
-                                 solver_parameters=solver_parameters)
+    solver = ensemble_tao_solver(rf, ensemble, solver_parameters=solver_parameters)
     solver.solve()
     its = solver.tao.getIterationNumber()
     assert its < 30

--- a/tests/test_parallel_arrays.py
+++ b/tests/test_parallel_arrays.py
@@ -5,8 +5,7 @@ from numpy import allclose
 
 from nudging.parallel_arrays import in_range
 
-from nudging.parallel_arrays import DistributedDataLayout1D, \
-    SharedArray, OwnedArray
+from nudging.parallel_arrays import DistributedDataLayout1D, SharedArray, OwnedArray
 
 partitions = [3, (2, 3, 4, 2)]
 
@@ -62,10 +61,7 @@ def test_distributed_data_layout(partition):
     assert layout.global_size == nglobal
     assert layout.offset == offset
 
-    max_indices = {
-        'l': nlocal,
-        'g': nglobal
-    }
+    max_indices = {"l": nlocal, "g": nglobal}
 
     # shift index: from_range == to_range
     for itype in max_indices.keys():
@@ -75,7 +71,7 @@ def test_distributed_data_layout(partition):
 
         # +ve index unchanged
         pos_shift = layout.transform_index(i, itype=itype, rtype=itype)
-        assert (pos_shift == i)
+        assert pos_shift == i
 
         # -ve index changed to +ve
         neg_shift = layout.transform_index(-i, itype=itype, rtype=itype)
@@ -86,43 +82,43 @@ def test_distributed_data_layout(partition):
     ilocal = 1
 
     # +ve index in local range
-    iglobal = layout.transform_index(ilocal, itype='l', rtype='g')
-    assert (iglobal == offset + ilocal)
+    iglobal = layout.transform_index(ilocal, itype="l", rtype="g")
+    assert iglobal == offset + ilocal
 
     # -ve index in local range
-    iglobal = layout.transform_index(-ilocal, itype='l', rtype='g')
-    assert (iglobal == offset + nlocal - ilocal)
+    iglobal = layout.transform_index(-ilocal, itype="l", rtype="g")
+    assert iglobal == offset + nlocal - ilocal
 
     ilocal = nlocal + 1
 
     # +ve index out of local range
     with pytest.raises(IndexError):
-        iglobal = layout.transform_index(ilocal, itype='l', rtype='g')
+        iglobal = layout.transform_index(ilocal, itype="l", rtype="g")
 
     # -ve index out of local range
     with pytest.raises(IndexError):
-        iglobal = layout.transform_index(-ilocal, itype='l', rtype='g')
+        iglobal = layout.transform_index(-ilocal, itype="l", rtype="g")
 
     # global address -> local address
 
     # +ve index in range
     iglobal = offset + 1
-    ilocal = layout.transform_index(iglobal, itype='g', rtype='l')
-    assert (ilocal == 1)
+    ilocal = layout.transform_index(iglobal, itype="g", rtype="l")
+    assert ilocal == 1
 
     assert layout.is_local(iglobal)
 
     # -ve index in range
     iglobal = -sum(partition) + offset + 1
-    ilocal = layout.transform_index(iglobal, itype='g', rtype='l')
-    assert (ilocal == 1)
+    ilocal = layout.transform_index(iglobal, itype="g", rtype="l")
+    assert ilocal == 1
 
     assert layout.is_local(iglobal)
 
     # +ve index out of local range
     iglobal = (offset + nlocal + 1) % nglobal
     with pytest.raises(IndexError):
-        ilocal = layout.transform_index(iglobal, itype='g', rtype='l')
+        ilocal = layout.transform_index(iglobal, itype="g", rtype="l")
 
     assert not layout.is_local(iglobal)
 
@@ -132,7 +128,7 @@ def test_distributed_data_layout(partition):
     # -ve index out of local range
     iglobal = -(nglobal - (offset + nlocal))
     with pytest.raises(IndexError):
-        ilocal = layout.transform_index(iglobal, itype='g', rtype='l')
+        ilocal = layout.transform_index(iglobal, itype="g", rtype="l")
 
     assert not layout.is_local(iglobal)
 
@@ -178,16 +174,16 @@ def test_shared_array(partition):
     # each rank sets its own elements using global access
     for i in range(local_size):
         j = array.offset + i
-        array.dglobal[j] = (array.rank + 1)*2
+        array.dglobal[j] = (array.rank + 1) * 2
 
     array.synchronise()
 
     # check all elements are correct
     for i in range(local_size):
-        assert array.dlocal[i] == (array.rank + 1)*2
+        assert array.dlocal[i] == (array.rank + 1) * 2
 
     for rank in range(array.comm.size):
-        check = (rank + 1)*2
+        check = (rank + 1) * 2
         offset = sum(partition[:rank])
         for i in range(partition[rank]):
             j = offset + i
@@ -236,7 +232,7 @@ def test_shared_array_manager(partition):
     array = SharedArray(partition=partition, dtype=int, comm=comm)
 
     # try to set a globally addressed element we don't own
-    bad_global_index = array.offset-1
+    bad_global_index = array.offset - 1
 
     with pytest.raises(IndexError):
         array.dglobal[bad_global_index] = 1
@@ -273,7 +269,7 @@ def test_owned_array():
     # initialise data
     for i in range(size):
         if array.is_owner():
-            array[i] = 2*(i+1)
+            array[i] = 2 * (i + 1)
         else:
             assert array[i] == 0
 
@@ -281,7 +277,7 @@ def test_owned_array():
 
     # check data
     for i in range(size):
-        assert array[i] == 2*(i+1)
+        assert array[i] == 2 * (i + 1)
 
     # only owner can modify
     if not array.is_owner():
@@ -289,22 +285,22 @@ def test_owned_array():
             array[0] = 0
 
     # resize
-    new_size = 2*size
+    new_size = 2 * size
     array.resize(new_size)
 
     assert array.size == new_size
 
     # check original data is unmodified
     for i in range(size):
-        assert array[i] == 2*(i+1)
+        assert array[i] == 2 * (i + 1)
 
     # initialise new data
     for i in range(new_size):
         if array.is_owner():
-            array[i] = 10*(i-5)
+            array[i] = 10 * (i - 5)
 
     array.synchronise()
 
     # check new data
     for i in range(new_size):
-        assert array[i] == 10*(i-5)
+        assert array[i] == 10 * (i - 5)

--- a/tests/test_parallel_resample.py
+++ b/tests/test_parallel_resample.py
@@ -16,8 +16,7 @@ def parallel_resample():
     s = [4, 3, 7, 0, 1, 5, 2, 6, 9, 8]
     simfilter.assimilation_step(s=s)
     for i in range(len(simfilter.ensemble)):
-        iglobal = simfilter.layout.transform_index(i, itype='l',
-                                                   rtype='g')
+        iglobal = simfilter.layout.transform_index(i, itype="l", rtype="g")
         s_val = simfilter.s_copy[iglobal]
         e_val = simfilter.ensemble[i][0]
         assert s_val - int(e_val.dat.data[:].min()) == 0


### PR DESCRIPTION
This PR adds functionality to make the linear SDE more user-friendly and cleans up the example file: 

1. Instead of hard-coded values, the configuration (Final time, number of steps, SDE parameters, particles per rank, etc.) are now read from either a YAML configuration file or from command line arguments.
2. All codes have been formatted using `black` for consistency.
3. Import errors, possibly arising from a new Firedrake version, have been fixed.
4. `gitignore` has been updated for a cleaner repository.